### PR TITLE
Ensure splash screen displays for minimum 2 seconds

### DIFF
--- a/PaperNexus/App.axaml.cs
+++ b/PaperNexus/App.axaml.cs
@@ -55,8 +55,8 @@ public partial class App : Application
             _splashScreen = new SplashScreen();
             _splashScreen.Show();
 
-            // Close the splash once the background host has started
-            _ = _backgroundHost.StartAsync().ContinueWith(_ =>
+            // Close the splash once the background host has started, but show it for at least 2 seconds
+            _ = Task.WhenAll(_backgroundHost.StartAsync(), Task.Delay(2000)).ContinueWith(_ =>
                 Dispatcher.UIThread.Post(() =>
                 {
                     _splashScreen?.Close();


### PR DESCRIPTION
## Summary
Modified the splash screen initialization logic to guarantee a minimum display duration of 2 seconds, improving the user experience by preventing the splash screen from closing too quickly.

## Key Changes
- Updated the splash screen closure logic to wait for both the background host startup AND a 2-second delay using `Task.WhenAll()`
- Changed from `_backgroundHost.StartAsync().ContinueWith()` to `Task.WhenAll(_backgroundHost.StartAsync(), Task.Delay(2000)).ContinueWith()`
- This ensures the splash screen remains visible for at least 2 seconds regardless of how quickly the background host initializes

## Implementation Details
The change uses `Task.WhenAll()` to create a composite task that completes only when both conditions are met:
1. The background host has finished starting
2. A 2-second delay has elapsed

This prevents the splash screen from disappearing too abruptly if the application initializes quickly, providing a more polished startup experience.

https://claude.ai/code/session_01Ws9gcTmoLpb6sGxxSuu9tY