### PR TITLE
Add explicit permissions to GitHub Actions workflows

### DIFF
--- a/.github/workflows/deploy-wallpaper-service.yml
+++ b/.github/workflows/deploy-wallpaper-service.yml
@@ -7,6 +7,9 @@ on:
       - 'v*'
   workflow_dispatch:
 
+permissions:
+  contents: write
+
 jobs:
   build:
     runs-on: windows-latest

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -4,6 +4,9 @@ on:
   pull_request:
     branches: ['main']
 
+permissions:
+  contents: read
+
 jobs:
   verify-build:
     runs-on: windows-latest


### PR DESCRIPTION
## Summary
This PR adds explicit permission declarations to GitHub Actions workflows to follow security best practices and improve workflow transparency.

## Key Changes
- **deploy-wallpaper-service.yml**: Added `permissions: contents: write` to enable the workflow to write to repository contents during deployment
- **pull-request.yml**: Added `permissions: contents: read` to explicitly declare read-only access needed for verification builds

## Implementation Details
These permission declarations follow the principle of least privilege by explicitly specifying what access each workflow requires. This improves security by:
- Making workflow permissions visible and auditable
- Preventing unintended permission escalation
- Aligning with GitHub's security recommendations for Actions workflows

The `contents: write` permission is necessary for the deployment workflow to create releases or update repository content, while the `contents: read` permission is sufficient for the pull request verification workflow which only needs to read repository contents.

https://claude.ai/code/session_01HZ4oCYyNELH4GP691ZsJax