### PR TITLE
Include native libraries in self-contained wallpaper service build

### DIFF
--- a/.github/workflows/deploy-wallpaper-service.yml
+++ b/.github/workflows/deploy-wallpaper-service.yml
@@ -34,6 +34,7 @@ jobs:
           --runtime win-x64 `
           --self-contained true `
           -p:PublishSingleFile=true `
+          -p:IncludeNativeLibrariesForSelfExtract=true `
           -p:PublishTrimmed=false `
           -p:Version=$version `
           --output ./publish/PaperNexus


### PR DESCRIPTION
## Summary
Updated the wallpaper service deployment workflow to include native libraries when publishing as a self-contained single file executable.

## Key Changes
- Added `-p:IncludeNativeLibrariesForSelfExtract=true` flag to the dotnet publish command for the Windows x64 build

## Implementation Details
This change ensures that any native dependencies required by the application are properly bundled into the self-contained executable. By enabling `IncludeNativeLibrariesForSelfExtract`, native libraries will be extracted at runtime, allowing the application to function correctly on target systems without requiring separate native library installations.

https://claude.ai/code/session_01Lf3L34ePgPqQdFQ1NpE112