### PR TITLE
Extract title from wallpaper filename before applying overlay

### DIFF
--- a/PaperNexus/SwitchWallpaper.cs
+++ b/PaperNexus/SwitchWallpaper.cs
@@ -67,6 +67,9 @@ internal sealed class SwitchWallpaper : ISwitchWallpaper, IAddSingleton<ISwitchW
         // Apply the title overlay here rather than at download time to preserve source image quality.
         // Save as PNG; if it exceeds 16 MB fall back to JPEG stepping quality down by 3% from 97%.
         var title = Path.GetFileNameWithoutExtension(next);
+        var separatorIndex = title.LastIndexOf(" - ", StringComparison.Ordinal);
+        if (separatorIndex >= 0)
+            title = title[..separatorIndex];
         using var img = await Image.LoadAsync(next).ConfigureAwait(false);
         using var annotated = img.Clone(o =>
         {


### PR DESCRIPTION
## Summary
Modified the wallpaper title extraction logic to remove the source attribution suffix from filenames before applying the title overlay to the image.

## Key Changes
- Added logic to detect and strip the " - " separator and everything after it from the wallpaper filename
- This extracts the clean title portion while discarding the source attribution that follows the separator
- The extraction happens before the image is loaded and annotated, ensuring only the clean title is displayed on the wallpaper

## Implementation Details
- Uses `LastIndexOf()` to find the rightmost occurrence of " - " in the filename
- Only processes the title if a separator is found (separatorIndex >= 0)
- Uses range operator (`[..separatorIndex]`) to extract the substring up to the separator
- Maintains the existing image quality preservation strategy (PNG with JPEG fallback)

https://claude.ai/code/session_01D4YjtxYkv74q6aJsfeEMWe