### PR TITLE
Use run number for non-tagged release versions

### DIFF
--- a/.github/workflows/deploy-wallpaper-service.yml
+++ b/.github/workflows/deploy-wallpaper-service.yml
@@ -28,7 +28,8 @@ jobs:
       shell: pwsh
       run: |
         $tag = '${{ github.ref_name }}'
-        $version = if ($tag -match '^v') { $tag.TrimStart('v') } else { '1.0.0' }
+        $runNumber = '${{ github.run_number }}'
+        $version = if ($tag -match '^v') { $tag.TrimStart('v') } else { "1.0.$runNumber" }
         dotnet publish PaperNexus/PaperNexus.csproj `
           --configuration Release `
           --runtime win-x64 `
@@ -45,8 +46,8 @@ jobs:
         GH_TOKEN: ${{ github.token }}
       run: |
         $isTag = '${{ github.ref }}' -match '^refs/tags/'
-        $releaseTag = if ($isTag) { '${{ github.ref_name }}' } else { 'latest' }
-        $releaseTitle = if ($isTag) { "Paper Nexus ${{ github.ref_name }}" } else { 'Paper Nexus (latest)' }
+        $runNumber = '${{ github.run_number }}'
+        $releaseTag = if ($isTag) { '${{ github.ref_name }}' } else { "v1.0.$runNumber" }
+        $releaseTitle = if ($isTag) { "Paper Nexus ${{ github.ref_name }}" } else { "Paper Nexus v1.0.$runNumber" }
         $notes = if ($isTag) { '--generate-notes' } else { '--notes "Automated build from main."' }
-        gh release delete $releaseTag --yes 2>&1 | Out-Null
         Invoke-Expression "gh release create '$releaseTag' --title '$releaseTitle' $notes ./publish/PaperNexus/PaperNexus.exe"


### PR DESCRIPTION
## Summary
Updated the deployment workflow to use GitHub's run number for versioning non-tagged builds, replacing the static fallback version with dynamic build identifiers.

## Key Changes
- Modified version assignment to use `github.run_number` when building from non-tagged commits, changing the fallback from `1.0.0` to `1.0.$runNumber`
- Updated release tag generation to use semantic versioning format (`v1.0.$runNumber`) instead of the `latest` tag for non-tagged builds
- Updated release title to include the versioned tag (`Paper Nexus v1.0.$runNumber`) for consistency with tagged releases
- Removed the `gh release delete` command that was previously cleaning up the `latest` release before creating a new one

## Implementation Details
These changes ensure that each automated build from the main branch receives a unique, incrementing version number based on the GitHub Actions run number, making it easier to track and identify specific builds while maintaining a consistent versioning scheme across tagged and non-tagged releases.

https://claude.ai/code/session_012p9MVGYUJcTvSCL3DoSZhF