### PR TITLE
Prevent concurrent instances and improve update batch reliability

### DIFF
--- a/PaperNexus/AutoUpdateService.cs
+++ b/PaperNexus/AutoUpdateService.cs
@@ -112,6 +112,15 @@ internal sealed class AutoUpdateService : IScheduleScopedJob
             @echo off
             timeout /t 2 /nobreak > nul
             move /y "{newExePath}" "{exePath}"
+            if errorlevel 1 (
+                timeout /t 3 /nobreak > nul
+                move /y "{newExePath}" "{exePath}"
+                if errorlevel 1 (
+                    timeout /t 5 /nobreak > nul
+                    move /y "{newExePath}" "{exePath}"
+                    if errorlevel 1 exit /b 1
+                )
+            )
             start "" "{exePath}"
             del "%~f0"
             """);

--- a/PaperNexus/Program.cs
+++ b/PaperNexus/Program.cs
@@ -13,6 +13,22 @@ internal sealed class Program
     [STAThread]
     public static void Main(string[] args)
     {
+        // Enforce single instance so concurrent update batch scripts cannot spawn
+        // multiple copies that all download and re-launch, creating an infinite loop.
+        using var mutex = new Mutex(false, "PaperNexus_SingleInstance");
+        bool acquired;
+        try
+        {
+            acquired = mutex.WaitOne(0, exitContext: false);
+        }
+        catch (AbandonedMutexException)
+        {
+            acquired = true; // previous instance crashed; we now own the mutex
+        }
+
+        if (!acquired)
+            return;
+
         using var loggerProvider = new FileLoggerProvider();
         var logger = loggerProvider.CreateLogger(nameof(Program));
 


### PR DESCRIPTION
## Summary
This PR improves the robustness of the auto-update mechanism by preventing multiple concurrent instances of PaperNexus from running and adding retry logic to the update batch script.

## Key Changes
- **Single Instance Enforcement**: Added a named mutex (`PaperNexus_SingleInstance`) in `Program.Main()` to ensure only one instance of the application can run at a time. This prevents concurrent update batch scripts from spawning multiple copies that could create an infinite loop of downloads and re-launches.
  - Handles `AbandonedMutexException` gracefully by assuming ownership if the previous instance crashed
  - Early return if another instance already holds the mutex

- **Update Batch Retry Logic**: Enhanced the auto-update batch script in `AutoUpdateService.cs` with exponential backoff retry attempts when moving the new executable fails:
  - Initial move attempt with 2-second timeout
  - First retry after 3-second delay if initial move fails
  - Second retry after 5-second delay if first retry fails
  - Exit with error code 1 if all three attempts fail
  - This addresses potential file locking issues during updates where the old executable may still be in use

## Implementation Details
- The mutex uses non-blocking wait (`WaitOne(0)`) to fail fast if another instance is already running
- The batch script uses `errorlevel` checks to detect move failures and implement the retry strategy
- Timeouts between retries allow the old process to fully release file locks before attempting the move again

https://claude.ai/code/session_01W7ag9EXTnioCmEjgoE5qMb