### PR TITLE
Add right padding to settings form StackPanel

### DIFF
--- a/PaperNexus/Views/MainWindow.axaml
+++ b/PaperNexus/Views/MainWindow.axaml
@@ -16,7 +16,7 @@
     <Grid RowDefinitions="*,Auto" Margin="20">
         <!-- Settings Form -->
         <ScrollViewer Grid.Row="0">
-            <StackPanel Spacing="14">
+            <StackPanel Spacing="14" Padding="0,0,16,0">
                 <!-- Current Wallpaper -->
                 <StackPanel Spacing="4">
                     <TextBlock Text="Current Wallpaper" FontWeight="SemiBold"/>


### PR DESCRIPTION
## Summary
Added right padding to the settings form StackPanel to improve layout spacing and prevent content from extending to the edge of the scrollable area.

## Changes
- Added `Padding="0,0,16,0"` to the StackPanel in the settings form, providing 16 units of right padding while maintaining zero padding on other sides

## Details
This adjustment ensures that content within the scrollable settings form has proper spacing from the right edge, which is particularly important when the scrollbar becomes visible. This prevents content from being cramped against the scrollbar and improves the overall visual appearance of the settings interface.

https://claude.ai/code/session_01P2pCytbgGgjgip7KMh4iPx