### PR TITLE
Fix StackPanel layout by replacing Padding with Margin

### DIFF
--- a/PaperNexus/Views/MainWindow.axaml
+++ b/PaperNexus/Views/MainWindow.axaml
@@ -16,7 +16,7 @@
     <Grid RowDefinitions="*,Auto" Margin="20">
         <!-- Settings Form -->
         <ScrollViewer Grid.Row="0">
-            <StackPanel Spacing="14" Padding="0,0,16,0">
+            <StackPanel Spacing="14" Margin="0,0,16,0">
                 <!-- Current Wallpaper -->
                 <StackPanel Spacing="4">
                     <TextBlock Text="Current Wallpaper" FontWeight="SemiBold"/>


### PR DESCRIPTION
## Summary
Changed the StackPanel layout property from `Padding` to `Margin` in the MainWindow settings form to ensure proper spacing and alignment of the UI elements.

## Key Changes
- Replaced `Padding="0,0,16,0"` with `Margin="0,0,16,0"` on the StackPanel in the settings form
  - This ensures the spacing is applied as external margin rather than internal padding, which is the correct approach for controlling distance between the StackPanel and its parent ScrollViewer

## Implementation Details
The change affects the visual layout of the settings form by adjusting how the 16-unit right-side spacing is applied. Using `Margin` instead of `Padding` provides better control over the element's external spacing relative to its container, which is particularly important when the StackPanel is inside a ScrollViewer.

https://claude.ai/code/session_013o6GEvh19ngJz2TX63B9eB