### PR TITLE
Display application version in main window footer

### DIFF
--- a/PaperNexus/ViewModels/WallpaperConfigViewModel.cs
+++ b/PaperNexus/ViewModels/WallpaperConfigViewModel.cs
@@ -99,6 +99,15 @@ public partial class WallpaperConfigViewModel : ObservableObject
     [ObservableProperty]
     private string _editCronExpression = "0 * * * *";
 
+    public string AppVersion
+    {
+        get
+        {
+            var v = typeof(WallpaperConfigViewModel).Assembly.GetName().Version;
+            return v is null ? string.Empty : $"v{v.Major}.{v.Minor}.{v.Build}";
+        }
+    }
+
     public WallpaperConfigViewModel()
     {
         _wallpapersFolder = string.Empty;

--- a/PaperNexus/Views/MainWindow.axaml
+++ b/PaperNexus/Views/MainWindow.axaml
@@ -148,7 +148,10 @@
 
         <!-- Footer -->
         <StackPanel Grid.Row="1" Spacing="8" Margin="0,14,0,0">
-            <TextBlock Text="{Binding StatusMessage}" TextWrapping="Wrap" FontSize="12"/>
+            <Grid ColumnDefinitions="*,Auto">
+                <TextBlock Grid.Column="0" Text="{Binding StatusMessage}" TextWrapping="Wrap" FontSize="12" VerticalAlignment="Bottom"/>
+                <TextBlock Grid.Column="1" Text="{Binding AppVersion}" FontSize="10" Opacity="0.35" VerticalAlignment="Bottom"/>
+            </Grid>
             <Grid ColumnDefinitions="*,8,*,8,*">
                 <Button Grid.Column="0" Content="⏭ Next Wallpaper" Command="{Binding NextWallpaperCommand}"
                         HorizontalAlignment="Stretch"/>


### PR DESCRIPTION
## Summary
Added application version display to the main window footer, showing the current version alongside the status message.

## Key Changes
- Added `AppVersion` property to `WallpaperConfigViewModel` that retrieves the assembly version and formats it as "vX.Y.Z"
- Updated the footer layout in `MainWindow.axaml` to display the version number in the bottom-right corner using a Grid layout
- Styled the version text with reduced opacity (0.35) and smaller font size (10) to keep it subtle and non-intrusive

## Implementation Details
- The `AppVersion` property dynamically reads from the assembly metadata, ensuring it always reflects the current build version
- The footer now uses a two-column Grid to position the status message on the left and version on the right
- Both text blocks are vertically aligned to the bottom for consistent baseline alignment

https://claude.ai/code/session_013WY53V9BTdJfbDcmpacJRF