### PR TITLE
Add bug report button to footer

### DIFF
--- a/PaperNexus/ViewModels/WallpaperConfigViewModel.cs
+++ b/PaperNexus/ViewModels/WallpaperConfigViewModel.cs
@@ -274,6 +274,17 @@ public partial class WallpaperConfigViewModel : ObservableObject
         }
     }
 
+    [RelayCommand]
+    private void ReportBug()
+    {
+        var version = App.AppVersion;
+        var body = $"**App Version:** {version}\n\n**Describe the bug:**\n\n\n**Steps to reproduce:**\n\n\n**Expected behavior:**\n\n";
+        var url = "https://github.com/0Keith/PaperNexus/issues/new"
+                + "?assignees=claude&labels=bug&title=Bug+Report"
+                + "&body=" + Uri.EscapeDataString(body);
+        Process.Start(new ProcessStartInfo(url) { UseShellExecute = true });
+    }
+
     private async Task SaveSettingsAsync()
     {
         try

--- a/PaperNexus/Views/MainWindow.axaml
+++ b/PaperNexus/Views/MainWindow.axaml
@@ -150,9 +150,12 @@
         <!-- Footer -->
         <StackPanel Grid.Row="1" Spacing="8" Margin="0,14,0,0">
             <TextBlock Text="{Binding StatusMessage}" TextWrapping="Wrap" FontSize="12"/>
-            <Grid ColumnDefinitions="*,Auto">
+            <Grid ColumnDefinitions="*,Auto,6,Auto">
                 <TextBlock Grid.Column="0" Text="{Binding StatusMessage}" TextWrapping="Wrap" FontSize="12" VerticalAlignment="Bottom"/>
                 <TextBlock Grid.Column="1" Text="{x:Static app:App.AppVersion}" FontSize="10" Opacity="0.35" VerticalAlignment="Bottom"/>
+                <Button Grid.Column="3" Content="🐛" Command="{Binding ReportBugCommand}"
+                        ToolTip.Tip="Report a bug on GitHub (assigned to claude)"
+                        Padding="5,2" FontSize="12" Opacity="0.6"/>
             </Grid>
             <Grid ColumnDefinitions="*,8,*">
                 <Button Grid.Column="0" Content="⏭ Next Wallpaper" Command="{Binding NextWallpaperCommand}"


### PR DESCRIPTION
## Summary
Added a bug report button to the application footer that allows users to quickly report issues on GitHub with pre-filled information.

## Key Changes
- Added `ReportBug()` relay command in `WallpaperConfigViewModel` that:
  - Constructs a GitHub issue URL with pre-filled template
  - Includes app version in the bug report body
  - Opens the GitHub issues page in the default browser with assignee and bug label pre-selected
- Updated the footer layout in `MainWindow.axaml` to include:
  - New bug report button (🐛 emoji) positioned next to the version number
  - Adjusted grid column definitions to accommodate the new button with spacing
  - Added tooltip explaining the button's purpose

## Implementation Details
- The bug report URL is constructed with `Uri.EscapeDataString()` to properly encode the pre-filled body template
- Button uses low opacity (0.6) to maintain visual hierarchy in the footer
- Pre-filled template includes sections for app version, bug description, reproduction steps, and expected behavior
- GitHub issue is configured to auto-assign to "claude" and apply the "bug" label

https://claude.ai/code/session_01DZjhRAFUEHgQ8GPShSZSpk