### PR TITLE
Fix PowerShell Export-PfxCertificate parameter name

### DIFF
--- a/.github/workflows/deploy-wallpaper-service.yml
+++ b/.github/workflows/deploy-wallpaper-service.yml
@@ -63,7 +63,7 @@ jobs:
             -HashAlgorithm SHA256 `
             -NotAfter (Get-Date).AddYears(5)
           $pfxPwd = ConvertTo-SecureString -String $certPassword -Force -AsPlainText
-          Export-PfxCertificate -Certificate $cert -FilePath $pfxPath -Password $pfxPwd | Out-Null
+          Export-PfxCertificate -Cert $cert -FilePath $pfxPath -Password $pfxPwd | Out-Null
 
           if ($env:GH_TOKEN) {
             $base64 = [Convert]::ToBase64String([IO.File]::ReadAllBytes($pfxPath))


### PR DESCRIPTION
## Summary
Corrected the parameter name used in the `Export-PfxCertificate` PowerShell cmdlet call within the wallpaper service deployment workflow.

## Changes
- Changed `-Certificate` parameter to `-Cert` in the `Export-PfxCertificate` cmdlet call to match the correct parameter name expected by the cmdlet

## Details
The `Export-PfxCertificate` cmdlet uses `-Cert` as the parameter name for specifying the certificate object, not `-Certificate`. This fix ensures the deployment workflow executes the certificate export command correctly during the build process.

https://claude.ai/code/session_01X4J8GUSmJivs5wGQA3oavv