### PR TITLE
Add automatic certificate expiry detection and renewal

### DIFF
--- a/.github/workflows/deploy-wallpaper-service.yml
+++ b/.github/workflows/deploy-wallpaper-service.yml
@@ -48,13 +48,29 @@ jobs:
       shell: pwsh
       run: |
         $pfxPath = "$env:TEMP\papernexus-sign.pfx"
+        $certPassword = $env:SIGNING_CERTIFICATE_PASSWORD
+        $needsNewCert = $false
 
         if ($env:SIGNING_CERTIFICATE) {
-          # Reuse the persistent cert stored in secrets
+          # Load the stored cert and check whether it is expired or expiring within 30 days
           [IO.File]::WriteAllBytes($pfxPath, [Convert]::FromBase64String($env:SIGNING_CERTIFICATE))
-          $certPassword = $env:SIGNING_CERTIFICATE_PASSWORD
+          $pfxPwd = ConvertTo-SecureString -String $certPassword -Force -AsPlainText
+          $cert = [System.Security.Cryptography.X509Certificates.X509Certificate2]::new($pfxPath, $pfxPwd)
+          $daysUntilExpiry = ($cert.NotAfter - (Get-Date)).TotalDays
+          $cert.Dispose()
+
+          if ($daysUntilExpiry -le 30) {
+            Write-Host "Certificate expires in $([math]::Floor($daysUntilExpiry)) day(s) — regenerating."
+            $needsNewCert = $true
+          } else {
+            Write-Host "Certificate valid for $([math]::Floor($daysUntilExpiry)) more day(s) — reusing."
+          }
         } else {
-          # First run: generate a cert and store it for all future runs
+          # No cert stored yet — generate on first run
+          $needsNewCert = $true
+        }
+
+        if ($needsNewCert) {
           $certPassword = [System.Guid]::NewGuid().ToString("N")
           $cert = New-SelfSignedCertificate `
             -Subject "CN=PaperNexus" `

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -115,10 +115,12 @@ All workflows run on `windows-latest` and use `actions/checkout@v6`.
 The release workflow signs `PaperNexus.exe` with a persistent self-signed certificate. The cert is auto-generated on the first run and stored back as repository secrets so every subsequent release is signed with the same identity, allowing SmartScreen reputation to accumulate.
 
 **How it works in CI:**
-1. If `SIGNING_CERTIFICATE` secret exists, the PFX is decoded and reused
-2. Otherwise a new cert is generated, and — if `GH_PAT` is set — written back to `SIGNING_CERTIFICATE` / `SIGNING_CERTIFICATE_PASSWORD` via `gh secret set` for all future runs
-3. `signtool.exe` (Windows 10 SDK, bundled on `windows-latest`) signs the exe with SHA-256 digest and a DigiCert RFC 3161 timestamp
-4. The PFX is deleted; the signed exe is uploaded to the GitHub Release
+1. If `SIGNING_CERTIFICATE` secret exists, the PFX is decoded and its expiry is checked
+2. If the cert is expired or expires within 30 days, a new cert is generated automatically and stored back to secrets (requires `GH_PAT`)
+3. Otherwise the stored cert is reused as-is
+4. If no `SIGNING_CERTIFICATE` secret exists, a new cert is generated on first run and stored via `gh secret set`
+5. `signtool.exe` (Windows 10 SDK, bundled on `windows-latest`) signs the exe with SHA-256 digest and a DigiCert RFC 3161 timestamp
+6. The PFX is deleted; the signed exe is uploaded to the GitHub Release
 
 **One-time setup** (only required to enable auto-persistence on first run):
 Add a single secret in repo Settings → Secrets and variables → Actions:
@@ -128,7 +130,7 @@ On the first workflow run with `GH_PAT` set, the cert is generated automatically
 
 Without `GH_PAT`, signing still works but the cert is ephemeral per-run (no reputation accumulation).
 
-**Cert renewal:** The cert is valid for 5 years. To force regeneration, delete the `SIGNING_CERTIFICATE` and `SIGNING_CERTIFICATE_PASSWORD` secrets — the next run will create a fresh cert. SmartScreen reputation is tied to the publisher name (`CN=PaperNexus`), so it carries forward after renewal.
+**Cert renewal:** The cert is valid for 5 years. The workflow automatically regenerates the cert when it has 30 or fewer days remaining, storing the new cert back to `SIGNING_CERTIFICATE` / `SIGNING_CERTIFICATE_PASSWORD` (requires `GH_PAT`). To force immediate regeneration, delete the `SIGNING_CERTIFICATE` and `SIGNING_CERTIFICATE_PASSWORD` secrets — the next run will create a fresh cert. SmartScreen reputation is tied to the publisher name (`CN=PaperNexus`), so it carries forward after renewal.
 
 **Limitations:** Self-signed certs are not rooted in a trusted CA, so SmartScreen warns on first download. Reputation accumulates across releases as long as the same cert is reused. To eliminate warnings immediately, replace with a purchased OV/EV certificate stored using the same `SIGNING_CERTIFICATE` / `SIGNING_CERTIFICATE_PASSWORD` secret names.
 


### PR DESCRIPTION
## Summary
Enhanced the code signing workflow to automatically detect when the persistent self-signed certificate is expiring and regenerate it proactively, rather than requiring manual intervention.

## Key Changes
- **Certificate expiry checking**: When a stored certificate exists, the workflow now loads it and checks if it expires within 30 days
- **Automatic regeneration**: If the certificate is expired or expiring soon, a new one is automatically generated and stored back to secrets (requires `GH_PAT`)
- **Improved logic flow**: Refactored the certificate handling into a clearer two-phase approach:
  1. Check if an existing cert should be reused or regenerated
  2. Generate a new cert if needed
- **Better logging**: Added informative messages showing how many days the certificate is valid for or how many days until expiry

## Implementation Details
- Uses `X509Certificate2` to load and inspect the stored PFX certificate
- Calculates days until expiry by comparing `NotAfter` with current date
- Properly disposes of the certificate object after inspection
- Maintains backward compatibility: first-run behavior unchanged, manual secret deletion still forces regeneration
- Documentation updated to reflect the new automatic renewal behavior

https://claude.ai/code/session_01LoDJtgTT7ckd5NvyEvwLsK