### PR TITLE
Add transient status message display for settings save confirmation

### DIFF
--- a/PaperNexus/ViewModels/WallpaperConfigViewModel.cs
+++ b/PaperNexus/ViewModels/WallpaperConfigViewModel.cs
@@ -91,6 +91,7 @@ public partial class WallpaperConfigViewModel : ObservableObject
     private WallpaperSource? _selectedSource;
 
     private bool _isLoading;
+    private CancellationTokenSource _statusCts = new();
 
     [ObservableProperty]
     private string _editName = string.Empty;
@@ -300,10 +301,26 @@ public partial class WallpaperConfigViewModel : ObservableObject
             settings.AnnotateWallpaper = AnnotateWallpaper;
             settings.Sources = Sources.ToList();
             await settings.SaveAsync();
+            await ShowTransientStatusAsync("✓ Settings saved.");
         }
         catch (Exception ex)
         {
             StatusMessage = $"✗ Error saving settings: {ex.Message}";
         }
+    }
+
+    private async Task ShowTransientStatusAsync(string message, int durationMs = 3000)
+    {
+        _statusCts.Cancel();
+        _statusCts = new CancellationTokenSource();
+        var cts = _statusCts;
+
+        StatusMessage = message;
+        try
+        {
+            await Task.Delay(durationMs, cts.Token);
+            StatusMessage = string.Empty;
+        }
+        catch (OperationCanceledException) { }
     }
 }

--- a/PaperNexus/Views/MainWindow.axaml
+++ b/PaperNexus/Views/MainWindow.axaml
@@ -149,7 +149,6 @@
 
         <!-- Footer -->
         <StackPanel Grid.Row="1" Spacing="8" Margin="0,14,0,0">
-            <TextBlock Text="{Binding StatusMessage}" TextWrapping="Wrap" FontSize="12"/>
             <Grid ColumnDefinitions="*,Auto,6,Auto">
                 <TextBlock Grid.Column="0" Text="{Binding StatusMessage}" TextWrapping="Wrap" FontSize="12" VerticalAlignment="Bottom"/>
                 <TextBlock Grid.Column="1" Text="{x:Static app:App.AppVersion}" FontSize="10" Opacity="0.35" VerticalAlignment="Bottom"/>


### PR DESCRIPTION
## Summary
This PR adds a transient status message that automatically clears after a few seconds when settings are saved, improving user feedback. It also removes a duplicate status message binding in the UI.

## Key Changes
- Added `ShowTransientStatusAsync()` method to display temporary status messages that auto-clear after 3 seconds
- Implemented `CancellationTokenSource` field to manage cancellation of pending status message timeouts
- Added success confirmation message ("✓ Settings saved.") when settings are successfully saved
- Removed duplicate `StatusMessage` TextBlock binding from the footer UI (kept the one in the Grid layout)

## Implementation Details
- The `ShowTransientStatusAsync()` method cancels any previously pending status message before displaying a new one, ensuring only one transient message is active at a time
- Uses `Task.Delay()` with a cancellation token to automatically clear the status message after the specified duration (default 3000ms)
- Gracefully handles `OperationCanceledException` when a new status message is triggered before the previous one completes
- The duplicate TextBlock removal in MainWindow.axaml consolidates the status message display to a single location within the Grid layout

https://claude.ai/code/session_01AikrAYzo9qaFndAr5NBXYT