### PR TITLE
Add progress reporting to auto-update service

### DIFF
--- a/PaperNexus/AutoUpdateService.cs
+++ b/PaperNexus/AutoUpdateService.cs
@@ -7,7 +7,7 @@ namespace PaperNexus;
 
 internal interface ICheckForUpdates
 {
-    Task CheckAsync();
+    Task CheckAsync(IProgress<string>? progress = null);
 }
 
 internal sealed class AutoUpdateService : ICheckForUpdates, IAddSingleton<ICheckForUpdates>
@@ -22,13 +22,14 @@ internal sealed class AutoUpdateService : ICheckForUpdates, IAddSingleton<ICheck
         _logger = logger.ThrowIfNull();
     }
 
-    public async Task CheckAsync()
+    public async Task CheckAsync(IProgress<string>? progress = null)
     {
         var current = typeof(AutoUpdateService).Assembly.GetName().Version;
         if (current is null)
             return;
 
         _logger.LogInformation("Checking for updates. Current version: {Version}", current);
+        progress?.Report("Checking for updates...");
 
         using var client = new HttpClient();
         client.DefaultRequestHeaders.UserAgent.ParseAdd("PaperNexus-AutoUpdater");
@@ -94,6 +95,7 @@ internal sealed class AutoUpdateService : ICheckForUpdates, IAddSingleton<ICheck
         var batchPath = Path.Combine(Path.GetDirectoryName(exePath)!, "update.bat");
 
         _logger.LogInformation("Downloading {Latest} from {Url}", latest, downloadUrl);
+        progress?.Report($"Downloading {tag}...");
 
         byte[] bytes;
         try
@@ -148,6 +150,8 @@ internal sealed class AutoUpdateService : ICheckForUpdates, IAddSingleton<ICheck
         });
 
         _logger.LogInformation("Update downloaded. Restarting to apply {Latest}...", latest);
+        progress?.Report("Restarting...");
+        await Task.Delay(500); // brief pause so the UI can display "Restarting..." before exit
         Environment.Exit(0);
     }
 }
@@ -166,5 +170,5 @@ internal sealed class AutoUpdateJob : IScheduleScopedJob
             CronExpression: CronExpression.Parse("0 3 * * *"),
             ExecuteOnStartup: true));
 
-    public Task ExecuteAsync() => _checkForUpdates.CheckAsync();
+    public Task ExecuteAsync() => _checkForUpdates.CheckAsync(progress: null);
 }

--- a/PaperNexus/ViewModels/WallpaperConfigViewModel.cs
+++ b/PaperNexus/ViewModels/WallpaperConfigViewModel.cs
@@ -336,10 +336,10 @@ public partial class WallpaperConfigViewModel : ObservableObject
             return;
         }
 
-        StatusMessage = "Checking for updates...";
+        var progress = new Progress<string>(msg => StatusMessage = msg);
         try
         {
-            await Task.Run(_checkForUpdates.CheckAsync);
+            await Task.Run(() => _checkForUpdates.CheckAsync(progress));
             await ShowTransientStatusAsync("✓ Already up to date.");
         }
         catch (Exception ex)


### PR DESCRIPTION
## Summary
Enhanced the auto-update service to report progress updates during the update check and download process, allowing the UI to display real-time status messages to the user.

## Key Changes
- Modified `ICheckForUpdates.CheckAsync()` to accept an optional `IProgress<string>` parameter for progress reporting
- Added progress reports at key stages:
  - "Checking for updates..." when the update check begins
  - "Downloading {tag}..." when the update file download starts
  - "Restarting..." before the application exits to apply the update
- Updated `WallpaperConfigViewModel` to create a `Progress<string>` instance that updates the `StatusMessage` property in real-time
- Added a 500ms delay before exit to allow the UI to display the "Restarting..." message before the application closes
- Updated the scheduled job executor to pass `null` for the progress parameter (no UI context in background execution)

## Implementation Details
- The progress parameter is optional with a default value of `null` to maintain backward compatibility
- Progress updates are reported at logical points in the update workflow to provide meaningful feedback to users
- The brief delay before exit ensures the final status message is visible to the user before the application restarts

https://claude.ai/code/session_011Wmuyih23TcoW96Gw5aZWZ