### PR TITLE
Add quick open button for wallpapers folder

### DIFF
--- a/PaperNexus/ViewModels/WallpaperConfigViewModel.cs
+++ b/PaperNexus/ViewModels/WallpaperConfigViewModel.cs
@@ -349,6 +349,22 @@ public partial class WallpaperConfigViewModel : ObservableObject
     }
 
     [RelayCommand]
+    private void OpenWallpapersFolder()
+    {
+        var folder = WallpapersFolder;
+        if (string.IsNullOrEmpty(folder))
+            return;
+        try
+        {
+            Process.Start(new ProcessStartInfo("explorer.exe", folder) { UseShellExecute = true });
+        }
+        catch (Exception ex)
+        {
+            _ = ShowTransientStatusAsync($"✗ Could not open folder: {ex.Message}");
+        }
+    }
+
+    [RelayCommand]
     private void ReportBug()
     {
         var version = App.AppVersion;

--- a/PaperNexus/Views/MainWindow.axaml
+++ b/PaperNexus/Views/MainWindow.axaml
@@ -98,7 +98,7 @@
                     <!-- Wallpapers Folder -->
                     <StackPanel Spacing="4">
                         <TextBlock Text="Wallpapers Folder" FontWeight="SemiBold"/>
-                        <Grid ColumnDefinitions="*,8,Auto">
+                        <Grid ColumnDefinitions="*,8,Auto,4,Auto">
                             <TextBox Grid.Column="0" Text="{Binding WallpapersFolder}"
                                      Watermark="e.g. C:/Users/YourName/Wallpapers"/>
                             <Button Grid.Column="2" Click="BrowseFolder_Click">
@@ -107,6 +107,13 @@
                                               Width="14" Height="14"/>
                                     <TextBlock Text="Browse..." VerticalAlignment="Center"/>
                                 </StackPanel>
+                            </Button>
+                            <Button Grid.Column="4"
+                                    Command="{Binding OpenWallpapersFolderCommand}"
+                                    IsEnabled="{Binding WallpapersFolder, Converter={x:Static StringConverters.IsNotNullOrEmpty}}"
+                                    ToolTip.Tip="Open wallpapers folder in Explorer">
+                                <PathIcon Data="M20 6H12L10 4H4C2.9 4 2 4.9 2 6V18C2 19.1 2.9 20 4 20H20C21.1 20 22 19.1 22 18V8C22 6.9 21.1 6 20 6ZM15 15H13V17H11V15H9V13H11V11H13V13H15V15Z"
+                                          Width="14" Height="14"/>
                             </Button>
                         </Grid>
                     </StackPanel>


### PR DESCRIPTION
## Summary
Added a convenient button to quickly open the configured wallpapers folder in Windows Explorer, improving user experience when managing wallpaper files.

## Key Changes
- **ViewModel**: Added `OpenWallpapersFolderCommand` relay command that launches the wallpapers folder in Explorer with error handling
- **UI**: Added a new button next to the "Browse..." button in the Wallpapers Folder section
  - Button displays a folder icon and includes a tooltip
  - Button is only enabled when a valid wallpapers folder path is configured
  - Updated grid column definitions to accommodate the new button

## Implementation Details
- The command uses `Process.Start()` with `explorer.exe` to open the folder
- Includes try-catch error handling that displays a transient status message if the folder cannot be opened
- The button is conditionally enabled using `StringConverters.IsNotNullOrEmpty` binding converter to prevent errors when no folder is set
- Follows the existing code patterns and styling conventions used in the application

https://claude.ai/code/session_01GoFx7iPDUFYRarzgyCsBQi