### PR TITLE
Relocate current wallpaper controls to sidebar

### DIFF
--- a/PaperNexus/Views/MainWindow.axaml
+++ b/PaperNexus/Views/MainWindow.axaml
@@ -52,6 +52,29 @@
                         </StackPanel>
                     </Button>
                 </Grid>
+                <StackPanel DockPanel.Dock="Bottom" Spacing="4" Margin="0,10,0,0">
+                    <StackPanel Orientation="Horizontal" Spacing="6">
+                        <TextBlock Text="Current Wallpaper" FontWeight="SemiBold" VerticalAlignment="Center"/>
+                        <Button Command="{Binding NextWallpaperCommand}"
+                                ToolTip.Tip="Switch to next wallpaper"
+                                Padding="4,2"
+                                Background="Transparent" BorderThickness="0">
+                            <PathIcon Data="M6 18L14.5 12L6 6V18ZM16 6V18H18V6H16Z"
+                                      Width="14" Height="14"/>
+                        </Button>
+                        <Button Click="DeleteWallpaper_Click"
+                                IsEnabled="{Binding CurrentWallpaperPath, Converter={x:Static StringConverters.IsNotNullOrEmpty}}"
+                                ToolTip.Tip="Delete current wallpaper"
+                                Padding="4,2"
+                                Background="Transparent" BorderThickness="0">
+                            <PathIcon Data="M9 3H15L16 4H20V6H4V4H8L9 3ZM5 7H19L18.1 20.1C18 21.2 17.1 22 16 22H8C6.9 22 6 21.2 5.9 20.1L5 7ZM10 10V19H12V10H10ZM14 10V19H16V10H14Z"
+                                      Width="14" Height="14"
+                                      Foreground="#E06C75"/>
+                        </Button>
+                    </StackPanel>
+                    <TextBlock Text="{Binding CurrentWallpaperName}" FontSize="13"
+                               TextWrapping="Wrap" Foreground="SteelBlue"/>
+                </StackPanel>
                 <ListBox ItemsSource="{Binding Sources}"
                          SelectedItem="{Binding SelectedSource}"
                          Background="#1E1E1E"
@@ -87,31 +110,6 @@
             <!-- Right column: All other settings -->
             <ScrollViewer Grid.Column="2">
                 <StackPanel Spacing="14" Margin="0,0,16,0">
-
-                    <!-- Current Wallpaper -->
-                    <StackPanel Spacing="4">
-                        <StackPanel Orientation="Horizontal" Spacing="6">
-                            <TextBlock Text="Current Wallpaper" FontWeight="SemiBold" VerticalAlignment="Center"/>
-                            <Button Command="{Binding NextWallpaperCommand}"
-                                    ToolTip.Tip="Switch to next wallpaper"
-                                    Padding="4,2"
-                                    Background="Transparent" BorderThickness="0">
-                                <PathIcon Data="M6 18L14.5 12L6 6V18ZM16 6V18H18V6H16Z"
-                                          Width="14" Height="14"/>
-                            </Button>
-                            <Button Click="DeleteWallpaper_Click"
-                                    IsEnabled="{Binding CurrentWallpaperPath, Converter={x:Static StringConverters.IsNotNullOrEmpty}}"
-                                    ToolTip.Tip="Delete current wallpaper"
-                                    Padding="4,2"
-                                    Background="Transparent" BorderThickness="0">
-                                <PathIcon Data="M9 3H15L16 4H20V6H4V4H8L9 3ZM5 7H19L18.1 20.1C18 21.2 17.1 22 16 22H8C6.9 22 6 21.2 5.9 20.1L5 7ZM10 10V19H12V10H10ZM14 10V19H16V10H14Z"
-                                          Width="14" Height="14"
-                                          Foreground="#E06C75"/>
-                            </Button>
-                        </StackPanel>
-                        <TextBlock Text="{Binding CurrentWallpaperName}" FontSize="13"
-                                   TextWrapping="Wrap" Foreground="SteelBlue"/>
-                    </StackPanel>
 
                     <!-- Wallpapers Folder -->
                     <StackPanel Spacing="4">


### PR DESCRIPTION
## Summary
Moved the "Current Wallpaper" section from the right panel to the left sidebar, positioning it above the wallpaper sources list for improved UI organization and accessibility.

## Key Changes
- Relocated the "Current Wallpaper" control section (including the wallpaper name display and action buttons) from the right scrollable panel to the left sidebar
- Positioned the section as a docked bottom element within the sidebar, above the sources ListBox
- Maintained all existing functionality including:
  - Next wallpaper button with command binding
  - Delete wallpaper button with conditional enabling based on current wallpaper path
  - Current wallpaper name display with text wrapping
  - All styling, tooltips, and icon definitions

## Implementation Details
- The control section is now docked to the bottom of the left sidebar with appropriate spacing (10px top margin, 4px internal spacing)
- Removed the original section from the right panel's ScrollViewer to avoid duplication
- All bindings and event handlers remain unchanged, ensuring no functional regression

https://claude.ai/code/session_01VYmu5D2sscwxEUkCn775kV