### PR TITLE
Improve wallpaper display names and refactor UI layout

### DIFF
--- a/PaperNexus/ViewModels/WallpaperConfigViewModel.cs
+++ b/PaperNexus/ViewModels/WallpaperConfigViewModel.cs
@@ -247,7 +247,7 @@ public partial class WallpaperConfigViewModel : ObservableObject
 
             var path = settings.CurrentWallpaperPath;
             CurrentWallpaperPath = path;
-            CurrentWallpaperName = string.IsNullOrEmpty(path) ? "(none)" : Path.GetFileName(path);
+            CurrentWallpaperName = string.IsNullOrEmpty(path) ? "(none)" : GetDisplayName(path);
         }
         finally
         {
@@ -280,7 +280,7 @@ public partial class WallpaperConfigViewModel : ObservableObject
                 return;
             }
             CurrentWallpaperPath = next;
-            CurrentWallpaperName = Path.GetFileName(next);
+            CurrentWallpaperName = GetDisplayName(next);
             await ShowTransientStatusAsync($"✓ Switched to: {CurrentWallpaperName}");
         }
         catch (Exception ex)
@@ -318,7 +318,7 @@ public partial class WallpaperConfigViewModel : ObservableObject
             }
 
             CurrentWallpaperPath = next;
-            CurrentWallpaperName = Path.GetFileName(next);
+            CurrentWallpaperName = GetDisplayName(next);
             await ShowTransientStatusAsync($"✓ Deleted and switched to: {CurrentWallpaperName}");
         }
         catch (Exception ex)
@@ -405,6 +405,13 @@ public partial class WallpaperConfigViewModel : ObservableObject
         {
             StatusMessage = $"✗ Error saving settings: {ex.Message}";
         }
+    }
+
+    private static string GetDisplayName(string path)
+    {
+        var nameWithoutExt = Path.GetFileNameWithoutExtension(path);
+        var lastSep = nameWithoutExt.LastIndexOf(" - ", StringComparison.Ordinal);
+        return lastSep > 0 ? nameWithoutExt[..lastSep] : Path.GetFileName(path);
     }
 
     internal async Task ShowTransientStatusAsync(string message, int durationMs = 3000)

--- a/PaperNexus/Views/MainWindow.axaml
+++ b/PaperNexus/Views/MainWindow.axaml
@@ -20,8 +20,8 @@
 
             <!-- Left column: Wallpaper Sources -->
             <DockPanel Grid.Column="0">
-                <TextBlock DockPanel.Dock="Top" Text="Wallpaper Sources" FontWeight="SemiBold" Margin="0,0,0,6"/>
                 <Grid DockPanel.Dock="Top" ColumnDefinitions="*,8,Auto,4,Auto,4,Auto" Margin="0,0,0,6">
+                    <TextBlock Grid.Column="0" Text="Wallpaper Sources" FontWeight="SemiBold" VerticalAlignment="Center"/>
                     <Button Grid.Column="2"
                             Click="AddSource_Click"
                             Padding="8,4">
@@ -52,17 +52,19 @@
                         </StackPanel>
                     </Button>
                 </Grid>
-                <StackPanel DockPanel.Dock="Bottom" Spacing="4" Margin="0,10,0,0">
-                    <StackPanel Orientation="Horizontal" Spacing="6">
-                        <TextBlock Text="Current Wallpaper" FontWeight="SemiBold" VerticalAlignment="Center"/>
-                        <Button Command="{Binding NextWallpaperCommand}"
+                <StackPanel DockPanel.Dock="Top" Spacing="4" Margin="0,0,0,6">
+                    <Grid ColumnDefinitions="*,Auto,4,Auto">
+                        <TextBlock Grid.Column="0" Text="Current Wallpaper" FontWeight="SemiBold" VerticalAlignment="Center"/>
+                        <Button Grid.Column="1"
+                                Command="{Binding NextWallpaperCommand}"
                                 ToolTip.Tip="Switch to next wallpaper"
                                 Padding="4,2"
                                 Background="Transparent" BorderThickness="0">
                             <PathIcon Data="M6 18L14.5 12L6 6V18ZM16 6V18H18V6H16Z"
                                       Width="14" Height="14"/>
                         </Button>
-                        <Button Click="DeleteWallpaper_Click"
+                        <Button Grid.Column="3"
+                                Click="DeleteWallpaper_Click"
                                 IsEnabled="{Binding CurrentWallpaperPath, Converter={x:Static StringConverters.IsNotNullOrEmpty}}"
                                 ToolTip.Tip="Delete current wallpaper"
                                 Padding="4,2"
@@ -71,7 +73,7 @@
                                       Width="14" Height="14"
                                       Foreground="#E06C75"/>
                         </Button>
-                    </StackPanel>
+                    </Grid>
                     <TextBlock Text="{Binding CurrentWallpaperName}" FontSize="13"
                                TextWrapping="Wrap" Foreground="SteelBlue"/>
                 </StackPanel>


### PR DESCRIPTION
## Summary
This PR improves the wallpaper display name handling and refactors the UI layout in the MainWindow to use a more consistent grid-based structure.

## Key Changes

**ViewModel Changes:**
- Added `GetDisplayName()` helper method that extracts the display name from wallpaper file paths by removing file extensions and stripping source metadata (text after " - " separator)
- Updated `LoadAsync()`, `NextWallpaper()`, and `DeleteCurrentWallpaper()` to use the new `GetDisplayName()` method instead of `Path.GetFileName()`
- This allows wallpapers with source information in their filenames (e.g., "Beautiful Sunset - Unsplash.jpg") to display as "Beautiful Sunset"

**UI Layout Changes:**
- Reorganized the "Wallpaper Sources" header from a standalone TextBlock to be part of a Grid layout alongside action buttons
- Refactored the "Current Wallpaper" section from a StackPanel-based layout to a Grid-based layout for better alignment and spacing control
- Changed the "Current Wallpaper" section from `DockPanel.Dock="Bottom"` to `DockPanel.Dock="Top"` to improve visual hierarchy
- Updated button positioning to use explicit Grid columns for more precise control

## Implementation Details
- The `GetDisplayName()` method uses `LastIndexOf()` to find the last occurrence of " - " separator, allowing for multiple hyphens in the actual wallpaper name
- Grid-based layouts provide better alignment consistency compared to StackPanel, especially for mixed content types (text + buttons)

https://claude.ai/code/session_01RGhji4KSemzXyBzNmnn5Ah