### PR TITLE
Add memory convention documentation for Claude sessions

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -191,6 +191,10 @@ No dedicated test projects exist yet. The PR workflow runs `dotnet test` with `c
 
 The `.claude/hooks/session-start.sh` script runs when Claude Code starts a remote session (`CLAUDE_CODE_REMOTE=true`). It installs the .NET 10 SDK via `apt-get` and restores NuGet packages for the solution.
 
+## Memory Convention
+
+When the user asks you to "remember" something, that means update `CLAUDE.md` with the relevant information so it persists across sessions.
+
 ## Guidelines for AI Assistants
 
 - Use .NET 10.0 for all new development


### PR DESCRIPTION
## Summary
Added documentation clarifying how to persist information across Claude Code sessions by updating the `CLAUDE.md` file.

## Changes
- Added "Memory Convention" section to `CLAUDE.md` explaining that user requests to "remember" something should result in updates to `CLAUDE.md` for persistence across sessions

## Details
This establishes a clear convention for maintaining context and institutional knowledge across multiple Claude Code sessions. When users ask the assistant to remember information, it should be documented in `CLAUDE.md` rather than relying on in-session memory that would be lost when the session ends.

https://claude.ai/code/session_01DV3bnDvD2nFfsv3Dw9hVkv