### PR TITLE
Add JSON path and regex filtering for wallpaper sources

### DIFF
--- a/PaperNexus/Core/WallpaperNexusSettings.cs
+++ b/PaperNexus/Core/WallpaperNexusSettings.cs
@@ -43,10 +43,19 @@ public class SlideshowSettings
     public WallpaperFillStyle FillStyle { get; set; } = WallpaperFillStyle.Fill;
 }
 
+public enum WallpaperSourceType
+{
+    HttpJson,
+}
+
 public class WallpaperSource
 {
     public string Name { get; set; } = string.Empty;
+    public WallpaperSourceType Type { get; set; } = WallpaperSourceType.HttpJson;
     public string Url { get; set; } = string.Empty;
+    public string ImageUrlJPath { get; set; } = "$[*].imageUrl";
+    public string TitleJPath { get; set; } = "$[*].title";
+    public string ImageUrlRegex { get; set; } = string.Empty;
     public string CronExpression { get; set; } = "0 * * * *";
     public bool IsEnabled { get; set; } = true;
 }

--- a/PaperNexus/HttpWallpaperSourceService.cs
+++ b/PaperNexus/HttpWallpaperSourceService.cs
@@ -1,3 +1,5 @@
+using System.Text.RegularExpressions;
+using Newtonsoft.Json.Linq;
 using PaperNexus.Core;
 
 namespace PaperNexus;
@@ -24,13 +26,28 @@ internal class HttpWallpaperSourceService
         }
 
         var json = await getResponse.Content.ReadAsStringAsync();
-        var response = JsonConvert.DeserializeObject<List<WallpaperImage>>(json);
-        if (response is null)
-        {
-            throw new Exception($"Source '{source.Name}' did not return valid json: " + json);
-        }
+        var images = ParseImages(source, json);
         _logger.LogInformation("Complete: " + new { watch.Elapsed });
-        return response;
+        return images;
+    }
+
+    private static List<WallpaperImage> ParseImages(WallpaperSource source, string json)
+    {
+        var token = JToken.Parse(json);
+        var imageUrls = token.SelectTokens(source.ImageUrlJPath).Select(t => t.Value<string>() ?? string.Empty).ToList();
+        var titles = token.SelectTokens(source.TitleJPath).Select(t => t.Value<string>() ?? string.Empty).ToList();
+
+        var images = imageUrls
+            .Zip(titles, (url, title) => new WallpaperImage { ImageUrl = url, Title = title })
+            .ToList();
+
+        if (!string.IsNullOrEmpty(source.ImageUrlRegex))
+        {
+            var regex = new Regex(source.ImageUrlRegex);
+            images = images.Where(img => regex.IsMatch(img.ImageUrl)).ToList();
+        }
+
+        return images;
     }
 }
 

--- a/PaperNexus/Views/WallpaperSourceDialog.axaml
+++ b/PaperNexus/Views/WallpaperSourceDialog.axaml
@@ -2,7 +2,7 @@
        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
        xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
        xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-       mc:Ignorable="d" d:DesignWidth="440" d:DesignHeight="320"
+       mc:Ignorable="d" d:DesignWidth="440" d:DesignHeight="460"
        x:Class="PaperNexus.Views.WallpaperSourceDialog"
        Title="Wallpaper Source"
        Icon="avares://PaperNexus/Assets/logo.png"
@@ -21,8 +21,36 @@
         </StackPanel>
 
         <StackPanel Spacing="4">
+            <TextBlock Text="Type" FontSize="12" Opacity="0.8"/>
+            <ComboBox x:Name="TypeBox" HorizontalAlignment="Stretch">
+                <ComboBoxItem Content="HTTP JSON" Tag="HttpJson"/>
+            </ComboBox>
+        </StackPanel>
+
+        <StackPanel Spacing="4">
             <TextBlock Text="URL" FontSize="12" Opacity="0.8"/>
             <TextBox x:Name="UrlBox" Watermark="https://example.com/feed.json"/>
+        </StackPanel>
+
+        <StackPanel Spacing="4">
+            <TextBlock Text="Image URL JPath" FontSize="12" Opacity="0.8"/>
+            <TextBox x:Name="ImageUrlJPathBox" Watermark="e.g. $[*].imageUrl"/>
+            <TextBlock Text="JPath expression to locate image URLs in the JSON response"
+                       FontSize="11" Opacity="0.5" TextWrapping="Wrap"/>
+        </StackPanel>
+
+        <StackPanel Spacing="4">
+            <TextBlock Text="Title JPath" FontSize="12" Opacity="0.8"/>
+            <TextBox x:Name="TitleJPathBox" Watermark="e.g. $[*].title"/>
+            <TextBlock Text="JPath expression to locate image titles in the JSON response"
+                       FontSize="11" Opacity="0.5" TextWrapping="Wrap"/>
+        </StackPanel>
+
+        <StackPanel Spacing="4">
+            <TextBlock Text="Image URL Regex (optional)" FontSize="12" Opacity="0.8"/>
+            <TextBox x:Name="ImageUrlRegexBox" Watermark="e.g. \.jpg$"/>
+            <TextBlock Text="Only images whose URL matches this regex will be downloaded"
+                       FontSize="11" Opacity="0.5" TextWrapping="Wrap"/>
         </StackPanel>
 
         <StackPanel Spacing="4">

--- a/PaperNexus/Views/WallpaperSourceDialog.axaml.cs
+++ b/PaperNexus/Views/WallpaperSourceDialog.axaml.cs
@@ -1,3 +1,4 @@
+using System.Text.RegularExpressions;
 using Avalonia.Controls;
 using Avalonia.Interactivity;
 using PaperNexus.Core;
@@ -11,6 +12,9 @@ public partial class WallpaperSourceDialog : Window
     public WallpaperSourceDialog()
     {
         InitializeComponent();
+        TypeBox.SelectedIndex = 0;
+        ImageUrlJPathBox.Text = "$[*].imageUrl";
+        TitleJPathBox.Text = "$[*].title";
     }
 
     public WallpaperSourceDialog(WallpaperSource source) : this()
@@ -18,6 +22,9 @@ public partial class WallpaperSourceDialog : Window
         DialogTitle.Text = "Edit Wallpaper Source";
         NameBox.Text = source.Name;
         UrlBox.Text = source.Url;
+        ImageUrlJPathBox.Text = source.ImageUrlJPath;
+        TitleJPathBox.Text = source.TitleJPath;
+        ImageUrlRegexBox.Text = source.ImageUrlRegex;
         CronBox.Text = source.CronExpression;
         EnabledBox.IsChecked = source.IsEnabled;
     }
@@ -26,6 +33,9 @@ public partial class WallpaperSourceDialog : Window
     {
         var name = NameBox.Text?.Trim() ?? string.Empty;
         var url = UrlBox.Text?.Trim() ?? string.Empty;
+        var imageUrlJPath = ImageUrlJPathBox.Text?.Trim() ?? "$[*].imageUrl";
+        var titleJPath = TitleJPathBox.Text?.Trim() ?? "$[*].title";
+        var imageUrlRegex = ImageUrlRegexBox.Text?.Trim() ?? string.Empty;
         var cron = CronBox.Text?.Trim();
 
         if (string.IsNullOrEmpty(name))
@@ -40,13 +50,42 @@ public partial class WallpaperSourceDialog : Window
             return;
         }
 
+        if (string.IsNullOrEmpty(imageUrlJPath))
+        {
+            ShowError("Image URL JPath is required.");
+            return;
+        }
+
+        if (string.IsNullOrEmpty(titleJPath))
+        {
+            ShowError("Title JPath is required.");
+            return;
+        }
+
+        if (!string.IsNullOrEmpty(imageUrlRegex))
+        {
+            try
+            {
+                _ = new Regex(imageUrlRegex);
+            }
+            catch (ArgumentException)
+            {
+                ShowError("Image URL Regex is not a valid regular expression.");
+                return;
+            }
+        }
+
         if (string.IsNullOrEmpty(cron))
             cron = "0 * * * *";
 
         Result = new WallpaperSource
         {
             Name = name,
+            Type = WallpaperSourceType.HttpJson,
             Url = url,
+            ImageUrlJPath = imageUrlJPath,
+            TitleJPath = titleJPath,
+            ImageUrlRegex = imageUrlRegex,
             CronExpression = cron,
             IsEnabled = EnabledBox.IsChecked ?? true,
         };


### PR DESCRIPTION
## Summary
Enhanced the wallpaper source configuration to support flexible JSON parsing with JPath expressions and optional regex filtering for image URLs. This allows users to extract wallpaper data from various JSON API responses without requiring exact schema matching.

## Key Changes
- **WallpaperSource model**: Added `Type`, `ImageUrlJPath`, `TitleJPath`, and `ImageUrlRegex` properties to support configurable JSON parsing
- **WallpaperSourceDialog UI**: 
  - Added source type selector (currently supports HTTP JSON)
  - Added input fields for Image URL JPath and Title JPath with helpful descriptions
  - Added optional Image URL Regex field for filtering results
  - Increased dialog height to accommodate new fields
- **WallpaperSourceDialog logic**:
  - Initialize default JPath expressions (`$[*].imageUrl` and `$[*].title`)
  - Validate JPath and regex inputs before saving
  - Populate fields when editing existing sources
- **HttpWallpaperSourceService**: 
  - Replaced hardcoded JSON deserialization with dynamic JPath-based parsing
  - Implemented `ParseImages()` method to extract image URLs and titles using JPath expressions
  - Added regex filtering to only include images matching the optional pattern

## Implementation Details
- Uses Newtonsoft.Json's JPath (JSONPath) for flexible JSON navigation
- Regex validation occurs at save time to provide immediate user feedback
- Images are paired by position (zip operation) between extracted URLs and titles
- Maintains backward compatibility with default JPath expressions for standard JSON structures

https://claude.ai/code/session_01KiYLyL4ZbzDWG4sc7FzBrG