### PR TITLE
Simplify app version display to show build number only

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -144,7 +144,7 @@ All workflows run on `windows-latest` and use `actions/checkout@v6`.
 
 - Default version: `1.0.0` in csproj `<Version>`
 - CI override: `-p:Version=$version` where `$version` is either the git tag (trimmed `v` prefix) or `1.0.{run_number}`
-- Runtime access: `Assembly.GetExecutingAssembly().GetName().Version` formatted as `v{Major}.{Minor}.{Build}` in `App.AppVersion`
+- Runtime access: `Assembly.GetExecutingAssembly().GetName().Version` formatted as `v{Build}` in `App.AppVersion`
 
 ### Code Signing (self-signed certificate)
 

--- a/PaperNexus/App.axaml.cs
+++ b/PaperNexus/App.axaml.cs
@@ -17,7 +17,7 @@ public partial class App : Application
 {
     public static string AppVersion { get; } =
         Assembly.GetExecutingAssembly().GetName().Version is Version v
-            ? $"v{v.Major}.{v.Minor}.{v.Build}"
+            ? $"v{v.Build}"
             : "v0.0.0";
 
     private IHost? _backgroundHost;


### PR DESCRIPTION
## Summary
Updated the app version formatting to display only the build number instead of the full semantic version (Major.Minor.Build).

## Changes
- Modified `App.AppVersion` property in `App.axaml.cs` to format the version string as `v{Build}` instead of `v{Major}.{Minor}.{Build}`
- Updated documentation in `CLAUDE.md` to reflect the new version format

## Details
The version is still sourced from `Assembly.GetExecutingAssembly().GetName().Version`, but the display format has been simplified to show only the build component. This aligns with the CI versioning strategy where the build number is set via `-p:Version=$version` (either from git tag or run number).

https://claude.ai/code/session_01N6bYCB5FJg4rfACffCPxbS