### PR TITLE
Fix styling for NonScrollableComboBox control

### DIFF
--- a/PaperNexus/Views/NonScrollableComboBox.cs
+++ b/PaperNexus/Views/NonScrollableComboBox.cs
@@ -5,6 +5,8 @@ namespace PaperNexus.Views;
 
 public class NonScrollableComboBox : ComboBox
 {
+    protected override Type StyleKeyOverride => typeof(ComboBox);
+
     protected override void OnPointerWheelChanged(PointerWheelEventArgs e)
     {
         if (IsDropDownOpen)


### PR DESCRIPTION
## Summary
Added StyleKeyOverride property to the NonScrollableComboBox class to ensure it uses the standard ComboBox styling instead of attempting to apply custom styling.

## Key Changes
- Added `StyleKeyOverride` property that returns `typeof(ComboBox)` to the NonScrollableComboBox class
- This ensures the control inherits the default ComboBox visual style while maintaining custom wheel scroll behavior

## Implementation Details
The StyleKeyOverride property is a protected override that explicitly directs the control to use ComboBox styling. This is necessary because custom controls in Avalonia typically need to explicitly specify their style key to avoid styling issues. By returning `typeof(ComboBox)`, the NonScrollableComboBox will apply standard ComboBox styles while preserving its custom pointer wheel handling logic that prevents scrolling when the dropdown is open.

https://claude.ai/code/session_01T8Q9Fxt4Ztw4oXAYFpmHhg