### PR TITLE
Improve wallpaper source test result messaging

### DIFF
--- a/PaperNexus/Views/WallpaperSourceDialog.axaml.cs
+++ b/PaperNexus/Views/WallpaperSourceDialog.axaml.cs
@@ -52,9 +52,11 @@ public partial class WallpaperSourceDialog : Window
                 TitleJPath = titleJPath,
             };
             var images = await service.GetImages(source);
-            var preview = images.Take(5).Select(img =>
+            var previewImages = images.Take(5).ToList();
+            var preview = previewImages.Select(img =>
                 $"Title: {img.Title}\nImage: {img.ImageUrl}");
-            ShowTestResult($"Success — {images.Count} image(s) found.\n\n{string.Join("\n\n", preview)}");
+            var previewNote = images.Count > previewImages.Count ? $" (showing first {previewImages.Count})" : string.Empty;
+            ShowTestResult($"Success — {images.Count} image(s) found{previewNote}.\n\n{string.Join("\n\n", preview)}");
         }
         catch (Exception ex)
         {


### PR DESCRIPTION
## Summary
Enhanced the test result dialog for wallpaper sources to provide clearer feedback when preview results are truncated.

## Key Changes
- Materialized the preview images collection to `List` to enable accurate count comparison
- Added conditional note to the success message indicating when results are truncated (e.g., "showing first 5")
- Improved user experience by explicitly communicating that only a subset of found images is being displayed

## Implementation Details
The change separates the preview image collection into its own variable before projection, allowing the code to compare the total image count against the preview count. When the preview is limited to fewer images than found, a clarifying note is appended to the result message.

https://claude.ai/code/session_01DHcTvkjnqjHxyMtvg5ybfQ