### PR TITLE
Add random wallpaper switching feature

### DIFF
--- a/PaperNexus/SwitchWallpaper.cs
+++ b/PaperNexus/SwitchWallpaper.cs
@@ -14,6 +14,7 @@ namespace PaperNexus;
 public interface ISwitchWallpaper
 {
     Task<string?> SwitchToNextAsync();
+    Task<string?> SwitchToRandomAsync();
 }
 
 internal sealed class SwitchWallpaper : ISwitchWallpaper, IAddSingleton<ISwitchWallpaper>
@@ -31,12 +32,7 @@ internal sealed class SwitchWallpaper : ISwitchWallpaper, IAddSingleton<ISwitchW
         if (!settings.IsConfigured)
             return null;
 
-        var allFiles = new DirectoryInfo(settings.Download.Folder)
-            .EnumerateFiles()
-            .Where(f => f.Extension.Equals(".png", StringComparison.OrdinalIgnoreCase)
-                     || f.Extension.Equals(".jpg", StringComparison.OrdinalIgnoreCase)
-                     || f.Extension.Equals(".jpeg", StringComparison.OrdinalIgnoreCase))
-            .ToList();
+        var allFiles = GetWallpaperFiles(settings.Download.Folder);
 
         if (allFiles.Count == 0)
             return null;
@@ -63,6 +59,38 @@ internal sealed class SwitchWallpaper : ISwitchWallpaper, IAddSingleton<ISwitchW
             next = files[(index + 1) % files.Count];
         }
 
+        return await ApplyWallpaperAsync(next, settings).ConfigureAwait(false);
+    }
+
+    public async Task<string?> SwitchToRandomAsync()
+    {
+        var settings = await WallpaperNexusSettings.LoadAsync().ConfigureAwait(false);
+        if (!settings.IsConfigured)
+            return null;
+
+        var allFiles = GetWallpaperFiles(settings.Download.Folder);
+
+        if (allFiles.Count == 0)
+            return null;
+
+        var candidates = allFiles.Select(f => f.FullName).ToList();
+        if (candidates.Count > 1)
+            candidates = candidates.Where(f => !f.Equals(settings.CurrentWallpaperPath, StringComparison.OrdinalIgnoreCase)).ToList();
+
+        var next = candidates[Random.Shared.Next(candidates.Count)];
+        return await ApplyWallpaperAsync(next, settings).ConfigureAwait(false);
+    }
+
+    private static List<FileInfo> GetWallpaperFiles(string folder) =>
+        new DirectoryInfo(folder)
+            .EnumerateFiles()
+            .Where(f => f.Extension.Equals(".png", StringComparison.OrdinalIgnoreCase)
+                     || f.Extension.Equals(".jpg", StringComparison.OrdinalIgnoreCase)
+                     || f.Extension.Equals(".jpeg", StringComparison.OrdinalIgnoreCase))
+            .ToList();
+
+    private async Task<string?> ApplyWallpaperAsync(string next, WallpaperNexusSettings settings)
+    {
         // Write to a fixed current file in the execution directory so the original files are never modified.
         // Apply the title overlay here rather than at download time to preserve source image quality.
         // Save as PNG; if it exceeds 16 MB fall back to JPEG stepping quality down by 3% from 97%.

--- a/PaperNexus/ViewModels/WallpaperConfigViewModel.cs
+++ b/PaperNexus/ViewModels/WallpaperConfigViewModel.cs
@@ -312,6 +312,34 @@ public partial class WallpaperConfigViewModel : ObservableObject
     }
 
     [RelayCommand]
+    private async Task RandomWallpaper()
+    {
+        try
+        {
+            if (_switchWallpaper is null)
+            {
+                StatusMessage = "✗ Wallpaper switcher not available.";
+                return;
+            }
+
+            StatusMessage = "Picking random wallpaper...";
+            var next = await Task.Run(_switchWallpaper.SwitchToRandomAsync);
+            if (next is null)
+            {
+                await ShowTransientStatusAsync("✗ No wallpapers found. Check your wallpapers folder setting.");
+                return;
+            }
+            CurrentWallpaperPath = next;
+            CurrentWallpaperName = GetDisplayName(next);
+            await ShowTransientStatusAsync($"✓ Switched to: {CurrentWallpaperName}");
+        }
+        catch (Exception ex)
+        {
+            await ShowTransientStatusAsync($"✗ Error switching wallpaper: {ex.Message}");
+        }
+    }
+
+    [RelayCommand]
     private async Task DeleteCurrentWallpaper()
     {
         var path = CurrentWallpaperPath;

--- a/PaperNexus/Views/MainWindow.axaml
+++ b/PaperNexus/Views/MainWindow.axaml
@@ -24,7 +24,7 @@
 
                 <!-- Current Wallpaper -->
                 <StackPanel DockPanel.Dock="Top" Spacing="4" Margin="0,0,0,14">
-                    <Grid ColumnDefinitions="*,Auto,4,Auto">
+                    <Grid ColumnDefinitions="*,Auto,4,Auto,4,Auto">
                         <TextBlock Grid.Column="0" Text="Current Wallpaper" FontWeight="SemiBold" VerticalAlignment="Center"/>
                         <Button Grid.Column="1"
                                 Command="{Binding NextWallpaperCommand}"
@@ -35,6 +35,14 @@
                                       Width="14" Height="14"/>
                         </Button>
                         <Button Grid.Column="3"
+                                Command="{Binding RandomWallpaperCommand}"
+                                ToolTip.Tip="Switch to random wallpaper"
+                                Padding="4,2"
+                                Background="Transparent" BorderThickness="0">
+                            <PathIcon Data="M10.59 9.17L5.41 4L4 5.41L9.17 10.59L10.59 9.17ZM14.5 4L16.54 6.04L4 18.59L5.41 20L17.96 7.46L20 9.5V4H14.5ZM14.83 13.41L13.42 14.82L16.55 17.95L14.5 20H20V14.5L17.96 16.54L14.83 13.41Z"
+                                      Width="14" Height="14"/>
+                        </Button>
+                        <Button Grid.Column="5"
                                 Click="DeleteWallpaper_Click"
                                 IsEnabled="{Binding CurrentWallpaperPath, Converter={x:Static StringConverters.IsNotNullOrEmpty}}"
                                 ToolTip.Tip="Delete current wallpaper"


### PR DESCRIPTION
## Summary
This PR adds a new "random wallpaper" feature to complement the existing "next wallpaper" functionality, allowing users to switch to a randomly selected wallpaper from their configured folder.

## Key Changes
- **Interface Update**: Added `SwitchToRandomAsync()` method to `ISwitchWallpaper` interface
- **Core Logic**: Implemented `SwitchToRandomAsync()` in `SwitchWallpaper` class with logic to:
  - Load and validate wallpaper settings
  - Retrieve all valid wallpaper files (.png, .jpg, .jpeg)
  - Exclude the currently active wallpaper from selection (when multiple options exist)
  - Apply the randomly selected wallpaper
- **Code Refactoring**: Extracted common wallpaper file enumeration logic into `GetWallpaperFiles()` helper method and wallpaper application logic into `ApplyWallpaperAsync()` method to reduce duplication
- **UI Implementation**: 
  - Added `RandomWallpaper()` command handler in `WallpaperConfigViewModel`
  - Added random wallpaper button to the UI toolbar next to the existing "next" button
  - Button includes appropriate icon and tooltip
  - Updated grid layout to accommodate the new button
- **Error Handling**: Consistent error handling and user feedback matching the existing "next wallpaper" implementation

## Notable Implementation Details
- Uses `Random.Shared` for thread-safe random selection
- Filters out current wallpaper from candidates when multiple wallpapers are available to ensure variety
- Maintains consistent async/await patterns and configuration validation with existing code
- UI button uses Material Design icon for visual consistency

https://claude.ai/code/session_01QYpLVxZsQUcruPWjEeeeKs