### PR TITLE
Remove IsEnabled binding from slideshow schedule and pattern panels

### DIFF
--- a/PaperNexus/Views/MainWindow.axaml
+++ b/PaperNexus/Views/MainWindow.axaml
@@ -195,7 +195,7 @@
                             </Grid>
 
                             <!-- Slideshow Schedule -->
-                            <StackPanel Spacing="4" IsEnabled="{Binding SlideshowEnabled}">
+                            <StackPanel Spacing="4">
                                 <TextBlock Text="Schedule" FontSize="12" Opacity="0.6"/>
                                 <StackPanel Orientation="Horizontal" Spacing="16">
                                     <RadioButton Content="Interval (mins)"
@@ -228,7 +228,7 @@
                             <Border Height="1" Background="#333"/>
 
                             <!-- Slideshow Pattern -->
-                            <StackPanel Spacing="4" IsEnabled="{Binding SlideshowEnabled}">
+                            <StackPanel Spacing="4">
                                 <TextBlock Text="Pattern" FontSize="12" Opacity="0.6"/>
                                 <v:NonScrollableComboBox ItemsSource="{x:Static vm:WallpaperConfigViewModel.SwitchPatternOptions}"
                                           SelectedItem="{Binding SelectedSlideshowPattern}"


### PR DESCRIPTION
## Summary
Removed the `IsEnabled="{Binding SlideshowEnabled}"` binding from two StackPanel controls in the slideshow configuration UI, allowing the schedule and pattern controls to remain enabled regardless of the slideshow enabled state.

## Changes
- Removed `IsEnabled` binding from the "Slideshow Schedule" StackPanel
- Removed `IsEnabled` binding from the "Slideshow Pattern" StackPanel

## Details
Previously, both the schedule and pattern configuration panels were conditionally disabled based on the `SlideshowEnabled` binding. This change allows users to configure these settings at any time, even when the slideshow feature is disabled. This may improve UX by allowing users to prepare slideshow settings before enabling the feature.

https://claude.ai/code/session_01M8q6exPo3BJ7GX6huEPbu9