### PR TITLE
Add automatic updates toggle to settings

### DIFF
--- a/PaperNexus/AutoUpdateService.cs
+++ b/PaperNexus/AutoUpdateService.cs
@@ -184,10 +184,15 @@ internal sealed class AutoUpdateJob : IScheduleScopedJob
         _checkForUpdates = checkForUpdates.ThrowIfNull();
     }
 
-    public Task<JobConfig> GetJobConfigAsync() =>
-        Task.FromResult(new JobConfig(
+    public async Task<JobConfig> GetJobConfigAsync()
+    {
+        var settings = await WallpaperNexusSettings.LoadAsync();
+        if (!settings.AutoUpdatesEnabled)
+            return new JobConfig();
+        return new JobConfig(
             CronExpression: CronExpression.Parse("0 3 * * *"),
-            ExecuteOnStartup: true));
+            ExecuteOnStartup: true);
+    }
 
     public Task ExecuteAsync() => _checkForUpdates.CheckAsync(forceUpdate: false, progress: null);
 }

--- a/PaperNexus/Core/WallpaperNexusSettings.cs
+++ b/PaperNexus/Core/WallpaperNexusSettings.cs
@@ -86,6 +86,7 @@ public class WallpaperNexusSettings
     public string CurrentWallpaperPath { get; set; } = string.Empty;
     public bool AnnotateWallpaper { get; set; } = true;
     public bool RunOnStartup { get; set; } = true;
+    public bool AutoUpdatesEnabled { get; set; } = true;
 
     [JsonProperty(ObjectCreationHandling = ObjectCreationHandling.Replace)]
     public List<WallpaperSource> Sources { get; set; } = new()

--- a/PaperNexus/ViewModels/WallpaperConfigViewModel.cs
+++ b/PaperNexus/ViewModels/WallpaperConfigViewModel.cs
@@ -122,6 +122,9 @@ public partial class WallpaperConfigViewModel : ObservableObject
     private bool _runOnStartup = true;
 
     [ObservableProperty]
+    private bool _autoUpdatesEnabled = true;
+
+    [ObservableProperty]
     private bool _slideshowEnabled = true;
 
     [ObservableProperty]
@@ -213,6 +216,7 @@ public partial class WallpaperConfigViewModel : ObservableObject
     partial void OnSelectedSlideshowPatternChanged(SwitchPatternOption value) => TriggerSave();
     partial void OnRetentionDaysChanged(int value) => TriggerSave();
     partial void OnAnnotateWallpaperChanged(bool value) => TriggerSave();
+    partial void OnAutoUpdatesEnabledChanged(bool value) => TriggerSave();
     partial void OnSlideshowEnabledChanged(bool value) => TriggerSave();
 
     partial void OnRunOnStartupChanged(bool value)
@@ -262,6 +266,7 @@ public partial class WallpaperConfigViewModel : ObservableObject
             RetentionDays = settings.Download.RetentionDays;
             AnnotateWallpaper = settings.AnnotateWallpaper;
             RunOnStartup = settings.RunOnStartup;
+            AutoUpdatesEnabled = settings.AutoUpdatesEnabled;
             SlideshowEnabled = settings.Slideshow.Enabled;
 
             Sources = new ObservableCollection<WallpaperSource>(settings.Sources);
@@ -491,6 +496,7 @@ public partial class WallpaperConfigViewModel : ObservableObject
             settings.Slideshow.Enabled = SlideshowEnabled;
             settings.AnnotateWallpaper = AnnotateWallpaper;
             settings.RunOnStartup = RunOnStartup;
+            settings.AutoUpdatesEnabled = AutoUpdatesEnabled;
             settings.Sources = Sources.ToList();
             await settings.SaveAsync();
             await ShowTransientStatusAsync("✓ Settings saved.");

--- a/PaperNexus/Views/MainWindow.axaml
+++ b/PaperNexus/Views/MainWindow.axaml
@@ -257,6 +257,9 @@
                             <CheckBox Content="Run on startup"
                                       IsChecked="{Binding RunOnStartup}"/>
                             <Border Height="1" Background="#333"/>
+                            <CheckBox Content="Automatic updates"
+                                      IsChecked="{Binding AutoUpdatesEnabled}"/>
+                            <Border Height="1" Background="#333"/>
                             <CheckBox Content="Show title annotation on wallpaper"
                                       IsChecked="{Binding AnnotateWallpaper}"/>
                         </StackPanel>


### PR DESCRIPTION
## Summary
This PR adds a user-configurable toggle to enable or disable automatic updates in the application. The auto-update job now respects this setting and will only execute when the feature is enabled.

## Key Changes
- Added `AutoUpdatesEnabled` boolean property to `WallpaperNexusSettings` (defaults to `true`)
- Updated `AutoUpdateJob.GetJobConfigAsync()` to check the setting and return an empty `JobConfig` when auto-updates are disabled
- Added `AutoUpdatesEnabled` observable property to `WallpaperConfigViewModel` with automatic save on change
- Added "Automatic updates" checkbox to the settings UI in `MainWindow.axaml`
- Integrated the setting into the view model's load and save operations

## Implementation Details
- The auto-update job gracefully handles the disabled state by returning a `JobConfig` with no cron expression or startup execution
- The setting is persisted to the application's settings file and loaded on startup
- The UI checkbox is bound bidirectionally to the view model property, triggering a save when toggled
- Default behavior maintains backward compatibility by enabling auto-updates for existing installations

https://claude.ai/code/session_01TAUonHbJ56adt8s1atBT9V