### PR TITLE
Set default wallpaper download folder to user profile

### DIFF
--- a/PaperNexus/Core/WallpaperNexusSettings.cs
+++ b/PaperNexus/Core/WallpaperNexusSettings.cs
@@ -69,7 +69,8 @@ public class WallpaperSource : ObservableObject
 
 public class DownloadSettings
 {
-    public string Folder { get; set; } = string.Empty;
+    public string Folder { get; set; } = Path.Combine(
+        Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), "wallpapers");
     public int ResolutionWidth { get; set; } = 0;
     public int ResolutionHeight { get; set; } = 0;
     public int RetentionDays { get; set; } = 365;


### PR DESCRIPTION
## Summary
Updated the default download folder path for wallpapers to use a sensible user-specific location instead of an empty string.

## Changes
- Modified `DownloadSettings.Folder` default value from an empty string to `~/wallpapers`
- The new default path is constructed using `Path.Combine()` with `Environment.GetFolderPath(Environment.SpecialFolder.UserProfile)` to ensure cross-platform compatibility
- This provides users with a reasonable default download location without requiring manual configuration

## Implementation Details
- Uses .NET's built-in environment APIs to resolve the user's home directory
- The path is constructed at initialization time, ensuring it adapts to the current user's profile
- Maintains backward compatibility as this only affects the default value for new configurations

https://claude.ai/code/session_01SqQKmpT3zPQDTPSUexdv88