### PR TITLE
Adjust grid column layout for wallpaper sources header

### DIFF
--- a/PaperNexus/Views/MainWindow.axaml
+++ b/PaperNexus/Views/MainWindow.axaml
@@ -65,7 +65,7 @@
                     </Button>
                 </StackPanel>
 
-                <Grid DockPanel.Dock="Top" ColumnDefinitions="*,8,Auto,4,Auto,4,Auto,4,Auto" Margin="0,0,0,6">
+                <Grid DockPanel.Dock="Top" ColumnDefinitions="Auto,4,Auto,*,Auto,4,Auto,4,Auto" Margin="0,0,0,6">
                     <TextBlock Grid.Column="0" Text="Wallpaper Sources" FontWeight="SemiBold" VerticalAlignment="Center"/>
                     <Button Grid.Column="2"
                             Command="{Binding DownloadNowCommand}"


### PR DESCRIPTION
## Summary
Updated the grid column definitions in the MainWindow to reorganize the layout of the wallpaper sources header section.

## Changes
- Modified `ColumnDefinitions` from `"*,8,Auto,4,Auto,4,Auto,4,Auto"` to `"Auto,4,Auto,*,Auto,4,Auto,4,Auto"`
  - Changed the first column from flexible (`*`) to fixed width (`Auto`)
  - Moved the flexible column (`*`) to the fourth position
  - This adjusts how space is distributed among the header controls

## Details
This layout change affects the "Wallpaper Sources" text block and associated buttons (likely Download Now and other action buttons). The new configuration prioritizes fixed sizing for the label and buttons while allowing the middle section to expand and fill available space, rather than having the label expand first.

https://claude.ai/code/session_015GUZ8aaKLPZiPdTU8eCpxr