### PR TITLE
Add tooltips to all buttons across the application

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -121,6 +121,7 @@ All rules are enforced via `.editorconfig`. Key conventions:
 - **Fields:** `readonly` preferred
 - **No `this.` qualification**
 - **Collection/object initializers:** Disabled (silent — don't suggest)
+- **Button tooltips:** Every `Button` in AXAML must have a `ToolTip.Tip` attribute. For buttons created in code-behind, use `ToolTip.SetTip(button, "...")`. This applies to all views; tray `NativeMenuItem`s are exempt (OS menus don't support tooltips).
 
 ### Suppressed Diagnostics
 

--- a/PaperNexus/Views/MainWindow.axaml
+++ b/PaperNexus/Views/MainWindow.axaml
@@ -76,6 +76,7 @@
                     </Button>
                     <Button Grid.Column="4"
                             Click="AddSource_Click"
+                            ToolTip.Tip="Add a new wallpaper source"
                             Padding="8,4">
                         <StackPanel Orientation="Horizontal" Spacing="4">
                             <PathIcon Data="M11 11V5H13V11H19V13H13V19H11V13H5V11H11Z"
@@ -86,6 +87,7 @@
                     <Button Grid.Column="6"
                             Click="EditSource_Click"
                             IsEnabled="{Binding SelectedSource, Converter={x:Static ObjectConverters.IsNotNull}}"
+                            ToolTip.Tip="Edit selected wallpaper source"
                             Padding="8,4">
                         <StackPanel Orientation="Horizontal" Spacing="4">
                             <PathIcon Data="M3 17.25V21H6.75L17.81 9.94L14.06 6.19L3 17.25ZM20.71 7.04C21.1 6.65 21.1 6.02 20.71 5.63L18.37 3.29C17.98 2.9 17.35 2.9 16.96 3.29L15.13 5.12L18.88 8.87L20.71 7.04Z"
@@ -96,6 +98,7 @@
                     <Button Grid.Column="8"
                             Command="{Binding DeleteSourceCommand}"
                             IsEnabled="{Binding SelectedSource, Converter={x:Static ObjectConverters.IsNotNull}}"
+                            ToolTip.Tip="Delete selected wallpaper source"
                             Padding="8,4">
                         <StackPanel Orientation="Horizontal" Spacing="4">
                             <PathIcon Data="M19 6.41L17.59 5L12 10.59L6.41 5L5 6.41L10.59 12L5 17.59L6.41 19L12 13.41L17.59 19L19 17.59L13.41 12Z"
@@ -150,7 +153,8 @@
                                 <Grid ColumnDefinitions="*,8,Auto,4,Auto">
                                     <TextBox Grid.Column="0" Text="{Binding Folder}"
                                              Watermark="e.g. C:/Users/YourName/Wallpapers"/>
-                                    <Button Grid.Column="2" Click="BrowseFolder_Click">
+                                    <Button Grid.Column="2" Click="BrowseFolder_Click"
+                                            ToolTip.Tip="Browse for wallpapers folder">
                                         <StackPanel Orientation="Horizontal" Spacing="4">
                                             <PathIcon Data="M10 4H4C2.9 4 2 4.9 2 6V18C2 19.1 2.9 20 4 20H20C21.1 20 22 19.1 22 18V8C22 6.9 21.1 6 20 6H12L10 4Z"
                                                       Width="14" Height="14"/>

--- a/PaperNexus/Views/MainWindow.axaml.cs
+++ b/PaperNexus/Views/MainWindow.axaml.cs
@@ -157,11 +157,13 @@ public partial class MainWindow : Window
     private async void DeleteWallpaper_Click(object? sender, Avalonia.Interactivity.RoutedEventArgs e)
     {
         var cancelBtn = new Button { Content = "Cancel" };
+        ToolTip.SetTip(cancelBtn, "Cancel deletion");
         var deleteBtn = new Button
         {
             Content = "Delete",
             Foreground = new SolidColorBrush(Color.Parse("#E06C75")),
         };
+        ToolTip.SetTip(deleteBtn, "Permanently delete wallpaper file");
         var dialog = new Window
         {
             Title = "Delete Wallpaper",

--- a/PaperNexus/Views/WallpaperSourceDialog.axaml
+++ b/PaperNexus/Views/WallpaperSourceDialog.axaml
@@ -68,8 +68,10 @@
 
         <Grid ColumnDefinitions="*,8,Auto,8,Auto" Margin="0,6,0,0">
             <Button Grid.Column="0" Content="Cancel" Click="Cancel_Click"
+                    ToolTip.Tip="Close without saving"
                     HorizontalAlignment="Stretch" HorizontalContentAlignment="Center"/>
             <Button Grid.Column="2" Click="Test_Click"
+                    ToolTip.Tip="Test the source configuration"
                     HorizontalAlignment="Stretch" Padding="16,6">
                 <StackPanel Orientation="Horizontal" Spacing="4">
                     <PathIcon Data="M8 5v14l11-7z"
@@ -78,6 +80,7 @@
                 </StackPanel>
             </Button>
             <Button Grid.Column="4" Click="Save_Click"
+                    ToolTip.Tip="Save wallpaper source"
                     HorizontalAlignment="Stretch" Padding="24,6">
                 <StackPanel Orientation="Horizontal" Spacing="4">
                     <PathIcon Data="M9 16.17L4.83 12L3.41 13.41L9 19L21 7L19.59 5.59Z"


### PR DESCRIPTION
## Summary
This PR adds descriptive tooltips to all buttons throughout the application to improve user experience and discoverability of button functionality.

## Key Changes
- **MainWindow.axaml:** Added `ToolTip.Tip` attributes to 4 buttons:
  - "Add Source" button: "Add a new wallpaper source"
  - "Edit Source" button: "Edit selected wallpaper source"
  - "Delete Source" button: "Delete selected wallpaper source"
  - "Browse Folder" button: "Browse for wallpapers folder"

- **WallpaperSourceDialog.axaml:** Added `ToolTip.Tip` attributes to 3 dialog buttons:
  - "Cancel" button: "Close without saving"
  - "Test" button: "Test the source configuration"
  - "Save" button: "Save wallpaper source"

- **MainWindow.axaml.cs:** Added tooltips to dynamically created buttons in the delete confirmation dialog:
  - "Cancel" button: "Cancel deletion"
  - "Delete" button: "Permanently delete wallpaper file"

- **CLAUDE.md:** Updated coding standards to document the new tooltip requirement: all `Button` elements in AXAML must include a `ToolTip.Tip` attribute, and buttons created in code-behind must use `ToolTip.SetTip()`. Native menu items are exempt as OS menus don't support tooltips.

## Implementation Details
- Tooltips provide clear, action-oriented descriptions of button functionality
- Consistent tooltip formatting across XAML and code-behind implementations
- Follows the established coding convention documented in the project guidelines

https://claude.ai/code/session_01UKY8EhHNd5qt5tMK5N63UF