### PR TITLE
Add debug mode and factory reset functionality

### DIFF
--- a/PaperNexus/Core/WallpaperNexusSettings.cs
+++ b/PaperNexus/Core/WallpaperNexusSettings.cs
@@ -89,6 +89,7 @@ public class WallpaperNexusSettings
     public bool AnnotateWallpaper { get; set; } = true;
     public bool RunOnStartup { get; set; } = true;
     public bool AutoUpdatesEnabled { get; set; } = true;
+    public bool DebugMode { get; set; }
 
     [JsonProperty(ObjectCreationHandling = ObjectCreationHandling.Replace)]
     public List<WallpaperSource> Sources { get; set; } = DefaultSources;

--- a/PaperNexus/ViewModels/WallpaperConfigViewModel.cs
+++ b/PaperNexus/ViewModels/WallpaperConfigViewModel.cs
@@ -130,6 +130,9 @@ public partial class WallpaperConfigViewModel : ObservableObject
     private bool _slideshowEnabled = true;
 
     [ObservableProperty]
+    private bool _debugMode;
+
+    [ObservableProperty]
     private string _statusMessage;
 
     [ObservableProperty]
@@ -233,6 +236,7 @@ public partial class WallpaperConfigViewModel : ObservableObject
     partial void OnAnnotateWallpaperChanged(bool value) => TriggerSave();
     partial void OnAutoUpdatesEnabledChanged(bool value) => TriggerSave();
     partial void OnSlideshowEnabledChanged(bool value) => TriggerSave();
+    partial void OnDebugModeChanged(bool value) => TriggerSave();
 
     partial void OnRunOnStartupChanged(bool value)
     {
@@ -283,6 +287,7 @@ public partial class WallpaperConfigViewModel : ObservableObject
             RunOnStartup = settings.RunOnStartup;
             AutoUpdatesEnabled = settings.AutoUpdatesEnabled;
             SlideshowEnabled = settings.Slideshow.Enabled;
+            DebugMode = settings.DebugMode;
 
             Sources = new ObservableCollection<WallpaperSource>(settings.Sources);
 
@@ -545,6 +550,7 @@ public partial class WallpaperConfigViewModel : ObservableObject
             settings.AnnotateWallpaper = AnnotateWallpaper;
             settings.RunOnStartup = RunOnStartup;
             settings.AutoUpdatesEnabled = AutoUpdatesEnabled;
+            settings.DebugMode = DebugMode;
             settings.Sources = Sources.ToList();
             await settings.SaveAsync();
             await ShowTransientStatusAsync("✓ Settings saved.");

--- a/PaperNexus/Views/MainWindow.axaml
+++ b/PaperNexus/Views/MainWindow.axaml
@@ -273,6 +273,11 @@
                             <Border Height="1" Background="#333"/>
                             <CheckBox Content="Show title annotation on wallpaper"
                                       IsChecked="{Binding AnnotateWallpaper}"/>
+                            <Border Height="1" Background="#333"/>
+                            <CheckBox x:Name="DebugModeCheckBox"
+                                      Content="Debug mode"
+                                      IsChecked="{Binding DebugMode}"
+                                      Click="DebugMode_Click"/>
                         </StackPanel>
                     </Border>
 
@@ -282,13 +287,25 @@
 
         <!-- Footer -->
         <StackPanel Grid.Row="1" Spacing="8" Margin="0,14,0,0">
-            <Grid ColumnDefinitions="*,Auto,4,Auto,6,Auto,6,Auto">
+            <Grid ColumnDefinitions="*,Auto,6,Auto,4,Auto,6,Auto,6,Auto">
                 <TextBlock Grid.Column="0" Text="{Binding StatusMessage}" Foreground="{Binding StatusForeground}" TextWrapping="Wrap" FontSize="12" VerticalAlignment="Bottom"/>
-                <TextBlock Grid.Column="1" x:Name="VersionLabel"
+                <Button Grid.Column="1"
+                        Click="FactoryReset_Click"
+                        ToolTip.Tip="Delete all application data and restart"
+                        Padding="5,2" Opacity="0.6">
+                    <StackPanel Orientation="Horizontal" Spacing="4">
+                        <PathIcon Data="M12 5V1L7 6L12 11V7C15.31 7 18 9.69 18 13C18 16.31 15.31 19 12 19C8.69 19 6 16.31 6 13H4C4 17.42 7.58 21 12 21C16.42 21 20 17.42 20 13C20 8.58 16.42 5 12 5Z"
+                                  Width="12" Height="12"
+                                  Foreground="#E06C75"/>
+                        <TextBlock Text="Factory Reset" FontSize="11" VerticalAlignment="Center"
+                                   Foreground="#E06C75"/>
+                    </StackPanel>
+                </Button>
+                <TextBlock Grid.Column="3" x:Name="VersionLabel"
                            Text="{x:Static app:App.AppVersion}"
                            FontSize="10" Opacity="0.35" VerticalAlignment="Bottom"
                            PointerPressed="OnVersionLabelPointerPressed"/>
-                <Button Grid.Column="3"
+                <Button Grid.Column="5"
                         x:Name="UpdateButton"
                         Command="{Binding CheckForUpdatesCommand}"
                         ToolTip.Tip="Check for updates (Shift+click to force reinstall)"
@@ -296,13 +313,13 @@
                     <PathIcon Data="M12 6V9L16 5L12 1V4C7.58 4 4 7.58 4 12C4 13.57 4.46 15.03 5.24 16.26L6.7 14.8C6.25 13.97 6 13.01 6 12C6 8.69 8.69 6 12 6ZM18.76 7.74L17.3 9.2C17.74 10.04 18 10.99 18 12C18 15.31 15.31 18 12 18V15L8 19L12 23V20C16.42 20 20 16.42 20 12C20 10.43 19.54 8.97 18.76 7.74Z"
                               Width="14" Height="14"/>
                 </Button>
-                <Button Grid.Column="5" Command="{Binding ReportBugCommand}"
+                <Button Grid.Column="7" Command="{Binding ReportBugCommand}"
                         ToolTip.Tip="Leave feedback on GitHub"
                         Padding="5,2" Opacity="0.6">
                     <PathIcon Data="M20 2H4C2.9 2 2 2.9 2 4V22L6 18H20C21.1 18 22 17.1 22 16V4C22 2.9 21.1 2 20 2ZM20 16H5.17L4 17.17V4H20V16Z"
                               Width="14" Height="14"/>
                 </Button>
-                <Button Grid.Column="7" Command="{Binding OpenHomepageCommand}"
+                <Button Grid.Column="9" Command="{Binding OpenHomepageCommand}"
                         ToolTip.Tip="Open PaperNexus on GitHub"
                         Padding="5,2" Opacity="0.6">
                     <PathIcon Data="M12 2C6.48 2 2 6.48 2 12C2 17.52 6.48 22 12 22C17.52 22 22 17.52 22 12C22 6.48 17.52 2 12 2ZM11 19.93C7.05 19.44 4 16.08 4 12C4 11.38 4.08 10.79 4.21 10.21L9 15V16C9 17.1 9.9 18 11 18V19.93ZM17.9 17.39C17.64 16.58 16.9 16 16 16H15V13C15 12.45 14.55 12 14 12H8V10H10C10.55 10 11 9.55 11 9V7H13C14.1 7 15 6.1 15 5V4.59C17.93 5.77 20 8.65 20 12C20 14.08 19.19 15.98 17.9 17.39Z"

--- a/PaperNexus/Views/MainWindow.axaml.cs
+++ b/PaperNexus/Views/MainWindow.axaml.cs
@@ -228,6 +228,145 @@ public partial class MainWindow : Window
         base.OnClosing(e);
     }
 
+    private static readonly string[] DebugConfirmations =
+    [
+        "Are you sure you want to enable debug mode?",
+        "Are you really sure?",
+        "Debug mode is for developers. Are you a developer?",
+        "Do you pinky promise you know what you're doing?",
+        "Have you consulted your system administrator?",
+        "Have you backed up your wallpapers? (You should.)",
+        "On a scale of 1 to 10, is your certainty at least 7?",
+        "Did you eat breakfast today? Mental clarity is important for decisions like this.",
+        "Have you considered that your wallpapers might judge you for this?",
+        "If a tree falls in a forest and no one hears it, should debug mode still be enabled?",
+        "The last person who enabled debug mode was never seen again. Continue?",
+        "We've notified your emergency contacts. Proceed anyway?",
+        "This action may void your wallpaper warranty. Accept?",
+        "NASA has been consulted and they recommend against it. Override NASA?",
+        "The prophecy foretold of one who would enable debug mode. Is it you, The Chosen One?",
+        "Final answer? No take-backs. This is legally binding in 47 countries.",
+        "Okay fine. But we warned you. SEVENTEEN TIMES. Enable debug mode?",
+    ];
+
+    private async void DebugMode_Click(object? sender, RoutedEventArgs e)
+    {
+        if (DataContext is not WallpaperConfigViewModel vm)
+            return;
+
+        // Only intercept when toggling ON
+        if (!DebugModeCheckBox.IsChecked.GetValueOrDefault())
+            return;
+
+        // Revert the check immediately — we'll set it if all 17 pass
+        DebugModeCheckBox.IsChecked = false;
+        vm.DebugMode = false;
+
+        for (var i = 0; i < DebugConfirmations.Length; i++)
+        {
+            var confirmed = await ShowYesNoDialog(
+                $"Confirmation {i + 1} of {DebugConfirmations.Length}",
+                DebugConfirmations[i]);
+
+            if (!confirmed)
+            {
+                var remaining = DebugConfirmations.Length - i;
+                await vm.ShowTransientStatusAsync(
+                    $"Debug mode cancelled. You only made it through {i} of {DebugConfirmations.Length} confirmations.", 5000);
+                return;
+            }
+        }
+
+        DebugModeCheckBox.IsChecked = true;
+        vm.DebugMode = true;
+        await vm.ShowTransientStatusAsync("Debug mode enabled. You absolute legend.", 5000);
+    }
+
+    private async void FactoryReset_Click(object? sender, RoutedEventArgs e)
+    {
+        var confirmed = await ShowYesNoDialog(
+            "Factory Reset",
+            "This will delete ALL application data (settings, logs, timers) and restart.\n\nYour downloaded wallpapers folder will NOT be deleted.\n\nAre you sure?");
+
+        if (!confirmed)
+            return;
+
+        var doubleConfirmed = await ShowYesNoDialog(
+            "Factory Reset — Final Confirmation",
+            "This cannot be undone. Seriously. Last chance to back out.");
+
+        if (!doubleConfirmed)
+            return;
+
+        try
+        {
+            var appDir = AppContext.BaseDirectory;
+            var exePath = Environment.ProcessPath
+                ?? Path.Combine(appDir, "PaperNexus.exe");
+
+            // Delete everything in the app directory except the running exe
+            foreach (var file in Directory.GetFiles(appDir))
+            {
+                if (string.Equals(Path.GetFullPath(file), Path.GetFullPath(exePath),
+                    StringComparison.OrdinalIgnoreCase))
+                    continue;
+                try { File.Delete(file); }
+                catch { /* skip locked files */ }
+            }
+
+            foreach (var dir in Directory.GetDirectories(appDir))
+            {
+                try { Directory.Delete(dir, recursive: true); }
+                catch { /* skip locked directories */ }
+            }
+
+            // Restart the application
+            Process.Start(new ProcessStartInfo(exePath) { UseShellExecute = true });
+            Environment.Exit(0);
+        }
+        catch (Exception ex)
+        {
+            if (DataContext is WallpaperConfigViewModel vm)
+                await vm.ShowTransientStatusAsync($"Factory reset failed: {ex.Message}", 5000);
+        }
+    }
+
+    private async Task<bool> ShowYesNoDialog(string title, string message)
+    {
+        var noBtn = new Button { Content = "No" };
+        ToolTip.SetTip(noBtn, "Cancel");
+        var yesBtn = new Button { Content = "Yes" };
+        ToolTip.SetTip(yesBtn, "Confirm");
+        var dialog = new Window
+        {
+            Title = title,
+            Width = 400,
+            Height = 160,
+            CanResize = false,
+            WindowStartupLocation = WindowStartupLocation.CenterOwner,
+            Background = new SolidColorBrush(Color.Parse("#2B2B2B")),
+            Content = new StackPanel
+            {
+                Margin = new Thickness(20),
+                Spacing = 16,
+                Children =
+                {
+                    new TextBlock { Text = message, TextWrapping = TextWrapping.Wrap },
+                    new StackPanel
+                    {
+                        Orientation = Orientation.Horizontal,
+                        Spacing = 8,
+                        HorizontalAlignment = HorizontalAlignment.Right,
+                        Children = { noBtn, yesBtn },
+                    },
+                },
+            },
+        };
+        noBtn.Click += (_, _) => dialog.Close(false);
+        yesBtn.Click += (_, _) => dialog.Close(true);
+        return await dialog.ShowDialog<bool>(this);
+    }
+
     private async Task SaveWindowPositionAsync()
     {
         try


### PR DESCRIPTION
## Summary
This PR adds two new features to the settings UI: a debug mode toggle with humorous multi-step confirmation dialogs, and a factory reset button that clears all application data while preserving downloaded wallpapers.

## Key Changes

- **Debug Mode Toggle**: Added a new checkbox in the settings panel that enables debug mode through a series of 17 increasingly absurd confirmation dialogs. The user must confirm all 17 prompts sequentially to enable the feature.
  - Added `DebugMode_Click` event handler that manages the multi-step confirmation flow
  - Created `DebugConfirmations` array with 17 humorous confirmation messages
  - Implemented transient status messages to show progress and final results

- **Factory Reset Button**: Added a new button in the footer that allows users to reset all application data
  - Implemented `FactoryReset_Click` event handler with dual confirmation dialogs
  - Deletes all files and directories in the app directory except the running executable
  - Automatically restarts the application after cleanup
  - Preserves the downloaded wallpapers folder (located outside app directory)
  - Includes error handling for locked files/directories

- **Dialog Helper**: Created `ShowYesNoDialog` utility method for consistent Yes/No confirmation dialogs with custom styling

- **ViewModel Updates**: 
  - Added `DebugMode` observable property to `WallpaperConfigViewModel`
  - Integrated debug mode persistence in settings load/save operations

- **Settings Persistence**: Added `DebugMode` property to `WallpaperNexusSettings` for storing the debug mode state

- **UI Layout**: Updated footer grid layout to accommodate the new Factory Reset button alongside existing controls

## Notable Implementation Details

- The debug mode confirmation flow reverts the checkbox immediately and only sets it if all confirmations pass
- Factory reset gracefully handles locked files by catching and skipping exceptions
- Both features include user-friendly transient status messages
- The factory reset button uses a red accent color (#E06C75) to indicate its destructive nature

https://claude.ai/code/session_01HvHpzHg3ke1uBj9PWdBmhH