### PR TITLE
fix: use slower-scaling outline pen formula

### DIFF
--- a/PaperNexus/SwitchWallpaper.cs
+++ b/PaperNexus/SwitchWallpaper.cs
@@ -121,7 +121,7 @@ internal sealed class SwitchWallpaper : ISwitchWallpaper, IAddSingleton<ISwitchW
             var pixel = color.ToPixel<Rgba32>();
             var outlineColor = pixel.R + pixel.G + pixel.B > 382 ? Color.Black : Color.White;
             var outlinePen = annotation.OutlineEnabled
-                ? Pens.Solid(outlineColor, Math.Max(1, fontSize / 17f))
+                ? Pens.Solid(outlineColor, 1 + fontSize / 36f)
                 : null;
             var brush = new SolidBrush(color);
             var position = annotation.Position switch


### PR DESCRIPTION
## Summary
- Replace `fontSize / 17f` with `1 + fontSize / 36f` for annotation outline pen width
- Produces thinner outlines that start at ~1.5px (size 18) and grow very slowly (3px at size 72)

## Test plan
- [ ] Verify outline visibility at font size 18 (default)
- [ ] Check outline at larger sizes (36, 72) stays proportional and thin
- [ ] Confirm no regression with OutlineEnabled toggled off

🤖 Generated with [Claude Code](https://claude.com/claude-code)