### PR TITLE
Reduce annotation outline thickness

### DIFF
--- a/PaperNexus/SwitchWallpaper.cs
+++ b/PaperNexus/SwitchWallpaper.cs
@@ -121,7 +121,7 @@ internal sealed class SwitchWallpaper : ISwitchWallpaper, IAddSingleton<ISwitchW
             var pixel = color.ToPixel<Rgba32>();
             var outlineColor = pixel.R + pixel.G + pixel.B > 382 ? Color.Black : Color.White;
             var outlinePen = annotation.OutlineEnabled
-                ? Pens.Solid(outlineColor, 1 + fontSize / 36f)
+                ? Pens.Solid(outlineColor, fontSize / 36f)
                 : null;
             var brush = new SolidBrush(color);
             var position = annotation.Position switch


### PR DESCRIPTION
## Summary
- Remove the `+1` base from the outline pen width formula, changing from `1 + fontSize/36` to `fontSize/36`
- At default font size 18, outline width drops from 1.5px to 0.5px for a thinner, less intrusive text outline

## Test plan
- [ ] Set a wallpaper with annotation enabled and verify the outline is visibly thinner
- [ ] Test with different font sizes to confirm proportional scaling

🤖 Generated with [Claude Code](https://claude.com/claude-code)