### PR TITLE
feat: installation screen for first-run setup

### DIFF
--- a/PaperNexus/App.axaml.cs
+++ b/PaperNexus/App.axaml.cs
@@ -43,8 +43,16 @@ public partial class App : Application
     {
         if (ApplicationLifetime is IClassicDesktopStyleApplicationLifetime desktop)
         {
-            // Keep running when the settings window is closed
+            // Keep running when any window is closed
             desktop.ShutdownMode = ShutdownMode.OnExplicitShutdown;
+
+            // In install mode, show only the install screen — skip all service/tray setup.
+            if (Program.IsInstallMode)
+            {
+                new Views.InstallScreen().Show();
+                base.OnFrameworkInitializationCompleted();
+                return;
+            }
 
             // Start background wallpaper services (download + switch)
             _backgroundHost = Host.CreateDefaultBuilder()

--- a/PaperNexus/Program.cs
+++ b/PaperNexus/Program.cs
@@ -15,6 +15,12 @@ internal sealed class Program
 
     internal static EventWaitHandle? ShowUIEvent { get; private set; }
     internal static bool IsDebugMode { get; private set; }
+    internal static bool IsInstallMode { get; private set; }
+
+    // Install path data exposed for InstallScreen to use when performing the actual install.
+    internal static string CurrentExePath { get; private set; } = string.Empty;
+    internal static string InstallDir { get; private set; } = string.Empty;
+    internal static string InstallExePath { get; private set; } = string.Empty;
 
     [STAThread]
     public static void Main(string[] args)
@@ -26,11 +32,16 @@ internal sealed class Program
         var (installDir, installPath) = GetInstallPaths();
         var currentPath = GetCurrentProcessPath();
 
+        // Cache paths so InstallScreen can reference them without recomputing.
+        InstallDir = installDir;
+        InstallExePath = installPath;
+        CurrentExePath = currentPath;
+
         // If running from a location other than the install directory, perform
         // first-run installation and then hand off to the installed copy.
         if (!IsRunningFromInstallLocation(currentPath, installPath))
         {
-            HandleNotInstalledLaunch(currentPath, installDir, installPath);
+            HandleNotInstalledLaunch(args);
             return;
         }
 
@@ -66,22 +77,21 @@ internal sealed class Program
     }
 
     // Handles startup when the exe is not yet at the install location.
-    // Signals any already-running instance first; if none is running, installs and relaunches.
-    private static void HandleNotInstalledLaunch(string currentPath, string installDir, string installPath)
+    // Signals any already-running instance first; if none is running, shows the install screen.
+    private static void HandleNotInstalledLaunch(string[] args)
     {
         // If a running instance exists, signal it to show its UI and exit without installing.
         if (TrySignalExistingInstance())
             return;
 
-        if (!TryInstall(currentPath, installDir, installPath))
-            return;
-
-        Process.Start(new ProcessStartInfo(installPath) { UseShellExecute = true });
+        // Show the install screen — it performs the actual copy and relaunch when confirmed.
+        IsInstallMode = true;
+        RunApp(args);
     }
 
     // Copies the exe to the install directory and migrates any adjacent data files.
     // Returns true if install succeeded or the installed copy already exists (race with another instance).
-    private static bool TryInstall(string currentPath, string installDir, string installPath)
+    internal static bool TryInstall(string currentPath, string installDir, string installPath)
     {
         try
         {

--- a/PaperNexus/Views/InstallScreen.axaml
+++ b/PaperNexus/Views/InstallScreen.axaml
@@ -1,0 +1,110 @@
+<Window xmlns="https://github.com/avaloniaui"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        x:Class="PaperNexus.Views.InstallScreen"
+        Width="400" Height="480"
+        WindowStartupLocation="CenterScreen"
+        SystemDecorations="None"
+        CanResize="False"
+        Topmost="True"
+        Background="#1E1E1E">
+
+    <Grid RowDefinitions="*,Auto,Auto,Auto,Auto,Auto">
+
+        <Image Grid.Row="0"
+               Source="avares://PaperNexus/Assets/logo.png"
+               Stretch="Uniform"
+               Margin="64,36,64,12" />
+
+        <TextBlock Grid.Row="1"
+                   Text="PaperNexus"
+                   FontSize="24"
+                   FontWeight="Bold"
+                   Foreground="#E0E0E0"
+                   HorizontalAlignment="Center"
+                   Margin="0,0,0,4" />
+
+        <TextBlock Grid.Row="2"
+                   Text="Automated wallpaper rotation for Windows"
+                   FontSize="13"
+                   Foreground="#707070"
+                   HorizontalAlignment="Center"
+                   Margin="0,0,0,20" />
+
+        <StackPanel Grid.Row="3"
+                    Margin="32,0,32,12">
+            <TextBlock Text="INSTALL LOCATION"
+                       FontSize="10"
+                       FontWeight="SemiBold"
+                       Foreground="#505050"
+                       LetterSpacing="1"
+                       Margin="0,0,0,4" />
+            <Grid ColumnDefinitions="*,8,Auto">
+                <TextBox Grid.Column="0"
+                         x:Name="InstallPathText"
+                         FontSize="12"
+                         Background="#262626"
+                         Foreground="#A0A0A0"
+                         BorderBrush="#383838"
+                         BorderThickness="1"
+                         CornerRadius="3"
+                         Padding="6,4"
+                         VerticalContentAlignment="Center"
+                         ToolTip.Tip="Folder where PaperNexus will be installed" />
+                <Button Grid.Column="2"
+                        x:Name="BrowseButton"
+                        Padding="10,4"
+                        Background="#2D2D2D"
+                        Foreground="#C0C0C0"
+                        BorderBrush="#404040"
+                        BorderThickness="1"
+                        CornerRadius="3"
+                        ToolTip.Tip="Choose a folder to install PaperNexus into"
+                        Click="OnBrowseClicked">
+                    <StackPanel Orientation="Horizontal" Spacing="5">
+                        <PathIcon Data="M10 4H4C2.9 4 2.01 4.9 2.01 6L2 18C2 19.1 2.9 20 4 20H20C21.1 20 22 19.1 22 18V8C22 6.9 21.1 6 20 6H12L10 4Z"
+                                  Width="12" Height="12" />
+                        <TextBlock Text="Browse" />
+                    </StackPanel>
+                </Button>
+            </Grid>
+        </StackPanel>
+
+        <CheckBox Grid.Row="4"
+                  x:Name="RunOnStartupCheckBox"
+                  Content="Run on startup"
+                  IsChecked="True"
+                  Foreground="#C0C0C0"
+                  Margin="32,0,32,0" />
+
+        <Grid Grid.Row="5"
+              ColumnDefinitions="*,Auto,8,Auto,*"
+              Margin="32,20,32,32">
+
+            <Button Grid.Column="1"
+                    x:Name="CancelButton"
+                    Content="Cancel"
+                    Padding="20,8"
+                    Background="#2D2D2D"
+                    Foreground="#C0C0C0"
+                    BorderBrush="#404040"
+                    BorderThickness="1"
+                    CornerRadius="4"
+                    ToolTip.Tip="Cancel installation and exit"
+                    Click="OnCancelClicked" />
+
+            <Button Grid.Column="3"
+                    x:Name="InstallButton"
+                    Content="Install"
+                    Padding="20,8"
+                    Background="#2C5F9E"
+                    Foreground="#E8E8E8"
+                    BorderBrush="#3A72B8"
+                    BorderThickness="1"
+                    CornerRadius="4"
+                    ToolTip.Tip="Install PaperNexus to the selected folder and launch it"
+                    Click="OnInstallClicked" />
+
+        </Grid>
+
+    </Grid>
+</Window>

--- a/PaperNexus/Views/InstallScreen.axaml.cs
+++ b/PaperNexus/Views/InstallScreen.axaml.cs
@@ -1,0 +1,108 @@
+using Avalonia.Controls;
+using Avalonia.Interactivity;
+using Avalonia.Platform.Storage;
+using Microsoft.Win32;
+using PaperNexus.Core;
+
+namespace PaperNexus.Views;
+
+public partial class InstallScreen : Window
+{
+    public InstallScreen()
+    {
+        InitializeComponent();
+        InstallPathText.Text = Program.InstallDir;
+    }
+
+    private async void OnBrowseClicked(object sender, RoutedEventArgs e)
+    {
+        try
+        {
+            var results = await StorageProvider.OpenFolderPickerAsync(new FolderPickerOpenOptions
+            {
+                Title = "Choose install folder",
+                AllowMultiple = false,
+            });
+
+            if (results is [var folder])
+            {
+                var selected = folder.Path.LocalPath;
+                // Always install into a "PaperNexus" subfolder of whatever the user picks.
+                InstallPathText.Text = Path.Combine(selected, "PaperNexus");
+            }
+        }
+        catch { /* picker cancelled or unavailable — leave path unchanged */ }
+    }
+
+    private async void OnInstallClicked(object sender, RoutedEventArgs e)
+    {
+        // Prevent double-click and give visual feedback while copying.
+        InstallButton.IsEnabled = false;
+        CancelButton.IsEnabled = false;
+        BrowseButton.IsEnabled = false;
+        InstallButton.Content = "Installing\u2026";
+
+        // Fall back to the default AppData path if the user cleared the field.
+        var installDir = InstallPathText.Text?.Trim();
+        if (string.IsNullOrEmpty(installDir))
+            installDir = Program.InstallDir;
+        var installExePath = Path.Combine(installDir, "PaperNexus.exe");
+
+        try
+        {
+            // Run the file copy off the UI thread to avoid blocking the window.
+            var success = await Task.Run(() =>
+                Program.TryInstall(Program.CurrentExePath, installDir, installExePath));
+
+            if (!success)
+            {
+                // Install failed — re-enable so the user can try again.
+                InstallButton.Content = "Install";
+                InstallButton.IsEnabled = true;
+                CancelButton.IsEnabled = true;
+                BrowseButton.IsEnabled = true;
+                return;
+            }
+
+            // Persist the startup preference to AppData so the installed app finds it on first launch.
+            // Settings always live at WallpaperNexusSettings.SettingsFilePath regardless of exe location.
+            // Only write fresh settings when none were migrated from alongside the source exe.
+            if (!File.Exists(WallpaperNexusSettings.SettingsFilePath))
+            {
+                var settings = new WallpaperNexusSettings
+                {
+                    RunOnStartup = RunOnStartupCheckBox.IsChecked == true,
+                };
+                await settings.SaveAsync();
+            }
+
+            // Write the Windows startup registry key pointing to the installed exe, not the current process.
+            // (App.UpdateStartupRegistration uses Environment.ProcessPath which is the un-installed copy.)
+            if (RunOnStartupCheckBox.IsChecked == true)
+            {
+#pragma warning disable CA1416
+                using var key = Registry.CurrentUser.OpenSubKey(
+                    @"SOFTWARE\Microsoft\Windows\CurrentVersion\Run", writable: true);
+                key?.SetValue("PaperNexus", $"\"{installExePath}\" --startup");
+#pragma warning restore CA1416
+            }
+
+            // Launch the newly-installed copy and exit the installer process.
+            Process.Start(new ProcessStartInfo(installExePath) { UseShellExecute = true });
+            Environment.Exit(0);
+        }
+        catch
+        {
+            // Restore interactive state so the user can retry or cancel.
+            InstallButton.Content = "Install";
+            InstallButton.IsEnabled = true;
+            CancelButton.IsEnabled = true;
+            BrowseButton.IsEnabled = true;
+        }
+    }
+
+    private void OnCancelClicked(object sender, RoutedEventArgs e)
+    {
+        Environment.Exit(0);
+    }
+}


### PR DESCRIPTION
## Summary

- Replaces the silent headless install with a visible Avalonia window matching the app's dark theme
- Shows logo, tagline, editable install path with Browse folder picker, run-on-startup checkbox, and Cancel/Install buttons
- Install button offloads file copy to a background thread; both async handlers are wrapped in try/catch to restore interactive state on failure
- Persists `RunOnStartup` preference to `settings.json` and the Windows registry startup key (pointing to the installed exe path) before relaunching

## Test plan

- [ ] Run `dotnet run --project PaperNexus --configuration Release` (no `--debug`) — install screen appears
- [ ] Click Cancel — process exits cleanly, nothing installed
- [ ] Run again, click Install with default path — app installs to `%LOCALAPPDATA%\PaperNexus\`, relaunches, install screen does not appear again
- [ ] Verify `HKCU\...\Run\PaperNexus` registry key points to installed exe when checkbox is checked
- [ ] Verify `%LOCALAPPDATA%\PaperNexus\settings.json` exists with `RunOnStartup` matching the checkbox
- [ ] Run `dotnet run --project PaperNexus --configuration Release -- --debug` — install screen does not appear

🤖 Generated with [Claude Code](https://claude.com/claude-code)