### PR TITLE
fix: exclude current wallpaper from retention cleanup deletion

### DIFF
--- a/PaperNexus.Tests/CronBuilderTests.cs
+++ b/PaperNexus.Tests/CronBuilderTests.cs
@@ -13,25 +13,25 @@ public class CronBuilderTests
     // --- Expected expressions per type ---
 
     [Theory]
-    [InlineData(1,  IntervalType.Seconds, "*/1 * * * * *")]
+    [InlineData(1, IntervalType.Seconds, "*/1 * * * * *")]
     [InlineData(30, IntervalType.Seconds, "*/30 * * * * *")]
     [InlineData(59, IntervalType.Seconds, "*/59 * * * * *")]
-    [InlineData(1,  IntervalType.Minutes, "*/1 * * * *")]
+    [InlineData(1, IntervalType.Minutes, "*/1 * * * *")]
     [InlineData(30, IntervalType.Minutes, "*/30 * * * *")]
     [InlineData(59, IntervalType.Minutes, "*/59 * * * *")]
-    [InlineData(1,  IntervalType.Hours,   "0 */1 * * *")]
-    [InlineData(6,  IntervalType.Hours,   "0 */6 * * *")]
-    [InlineData(23, IntervalType.Hours,   "0 */23 * * *")]
-    [InlineData(1,  IntervalType.Days,    "0 0 */1 * *")]
-    [InlineData(7,  IntervalType.Days,    "0 0 */7 * *")]
-    [InlineData(28, IntervalType.Days,    "0 0 */28 * *")]
-    [InlineData(1,  IntervalType.Weeks,   "0 0 */7 * *")]
-    [InlineData(2,  IntervalType.Weeks,   "0 0 */14 * *")]
-    [InlineData(4,  IntervalType.Weeks,   "0 0 */28 * *")]
-    [InlineData(1,  IntervalType.Months,  "0 0 1 */1 *")]
-    [InlineData(3,  IntervalType.Months,  "0 0 1 */3 *")]
-    [InlineData(12, IntervalType.Months,  "0 0 1 */12 *")]
-    [InlineData(1,  IntervalType.Years,   "0 0 1 1 *")]
+    [InlineData(1, IntervalType.Hours, "0 */1 * * *")]
+    [InlineData(6, IntervalType.Hours, "0 */6 * * *")]
+    [InlineData(23, IntervalType.Hours, "0 */23 * * *")]
+    [InlineData(1, IntervalType.Days, "0 0 */1 * *")]
+    [InlineData(7, IntervalType.Days, "0 0 */7 * *")]
+    [InlineData(28, IntervalType.Days, "0 0 */28 * *")]
+    [InlineData(1, IntervalType.Weeks, "0 0 */7 * *")]
+    [InlineData(2, IntervalType.Weeks, "0 0 */14 * *")]
+    [InlineData(4, IntervalType.Weeks, "0 0 */28 * *")]
+    [InlineData(1, IntervalType.Months, "0 0 1 */1 *")]
+    [InlineData(3, IntervalType.Months, "0 0 1 */3 *")]
+    [InlineData(12, IntervalType.Months, "0 0 1 */12 *")]
+    [InlineData(1, IntervalType.Years, "0 0 1 1 *")]
     public void BuildIntervalCron_ReturnsExpectedExpression(int interval, IntervalType type, string expected)
     {
         var result = WallpaperConfigViewModel.BuildIntervalCron(interval, type);
@@ -41,17 +41,17 @@ public class CronBuilderTests
     // --- Clamping: values at or below zero clamp to 1, values above max clamp to max ---
 
     [Theory]
-    [InlineData(0,   IntervalType.Seconds)]  // clamps to 1
-    [InlineData(-5,  IntervalType.Seconds)]  // clamps to 1
+    [InlineData(0, IntervalType.Seconds)]  // clamps to 1
+    [InlineData(-5, IntervalType.Seconds)]  // clamps to 1
     [InlineData(100, IntervalType.Seconds)]  // clamps to 59
-    [InlineData(0,   IntervalType.Minutes)]  // clamps to 1
+    [InlineData(0, IntervalType.Minutes)]  // clamps to 1
     [InlineData(100, IntervalType.Minutes)]  // clamps to 59
-    [InlineData(0,   IntervalType.Hours)]    // clamps to 1
-    [InlineData(50,  IntervalType.Hours)]    // clamps to 23
-    [InlineData(0,   IntervalType.Days)]     // clamps to 1
-    [InlineData(99,  IntervalType.Weeks)]    // weeks * 7 clamped to 28
-    [InlineData(0,   IntervalType.Months)]   // clamps to 1
-    [InlineData(99,  IntervalType.Months)]   // clamps to 12
+    [InlineData(0, IntervalType.Hours)]    // clamps to 1
+    [InlineData(50, IntervalType.Hours)]    // clamps to 23
+    [InlineData(0, IntervalType.Days)]     // clamps to 1
+    [InlineData(99, IntervalType.Weeks)]    // weeks * 7 clamped to 28
+    [InlineData(0, IntervalType.Months)]   // clamps to 1
+    [InlineData(99, IntervalType.Months)]   // clamps to 12
     public void BuildIntervalCron_ClampsToValidRange(int interval, IntervalType type)
     {
         var result = WallpaperConfigViewModel.BuildIntervalCron(interval, type);
@@ -64,24 +64,24 @@ public class CronBuilderTests
     // --- Cronos parseability: every valid input must parse without throwing ---
 
     [Theory]
-    [InlineData(1,  IntervalType.Seconds)]
+    [InlineData(1, IntervalType.Seconds)]
     [InlineData(30, IntervalType.Seconds)]
     [InlineData(59, IntervalType.Seconds)]
-    [InlineData(1,  IntervalType.Minutes)]
+    [InlineData(1, IntervalType.Minutes)]
     [InlineData(30, IntervalType.Minutes)]
     [InlineData(59, IntervalType.Minutes)]
-    [InlineData(1,  IntervalType.Hours)]
+    [InlineData(1, IntervalType.Hours)]
     [InlineData(12, IntervalType.Hours)]
     [InlineData(23, IntervalType.Hours)]
-    [InlineData(1,  IntervalType.Days)]
+    [InlineData(1, IntervalType.Days)]
     [InlineData(14, IntervalType.Days)]
     [InlineData(28, IntervalType.Days)]
-    [InlineData(1,  IntervalType.Weeks)]
-    [InlineData(4,  IntervalType.Weeks)]
-    [InlineData(1,  IntervalType.Months)]
-    [InlineData(6,  IntervalType.Months)]
+    [InlineData(1, IntervalType.Weeks)]
+    [InlineData(4, IntervalType.Weeks)]
+    [InlineData(1, IntervalType.Months)]
+    [InlineData(6, IntervalType.Months)]
     [InlineData(12, IntervalType.Months)]
-    [InlineData(1,  IntervalType.Years)]
+    [InlineData(1, IntervalType.Years)]
     public void BuildIntervalCron_AllOutputs_ParseableByChronos(int interval, IntervalType type)
     {
         var expression = WallpaperConfigViewModel.BuildIntervalCron(interval, type);

--- a/PaperNexus.Tests/DownloadWallpapersTests.cs
+++ b/PaperNexus.Tests/DownloadWallpapersTests.cs
@@ -85,11 +85,11 @@ public class DownloadWallpapersTests : IDisposable
     // Without the fix, Path.GetExtension("image.jpg?sig=abc") returns ".jpg?sig=abc",
     // making the extension contain the query string and producing an invalid filename.
     [Theory]
-    [InlineData("https://example.com/photo.jpg?sig=abc123&se=2025",           "photo",  ".jpg")]
-    [InlineData("https://example.com/photo.png?X-Goog-Signature=xyz",         "photo",  ".png")]
-    [InlineData("https://example.com/photo.jpg#anchor",                        "photo",  ".jpg")]
-    [InlineData("https://example.com/photo.jpg?token=x&ver=2#section",        "photo",  ".jpg")]
-    [InlineData("https://example.com/api/image?format=jpg&w=3840",            "image",  ".png")] // no clean ext → .png fallback
+    [InlineData("https://example.com/photo.jpg?sig=abc123&se=2025", "photo", ".jpg")]
+    [InlineData("https://example.com/photo.png?X-Goog-Signature=xyz", "photo", ".png")]
+    [InlineData("https://example.com/photo.jpg#anchor", "photo", ".jpg")]
+    [InlineData("https://example.com/photo.jpg?token=x&ver=2#section", "photo", ".jpg")]
+    [InlineData("https://example.com/api/image?format=jpg&w=3840", "image", ".png")] // no clean ext → .png fallback
     public async Task Download_UrlWithQueryString_ProducesCleanFilename(
         string imageUrl, string expectedStem, string expectedExt)
     {
@@ -410,6 +410,62 @@ public class DownloadWallpapersTests : IDisposable
         Assert.Equal(WallpaperNexusSettings.DefaultSources.Count, loaded.Sources.Count);
     }
 
+    [Fact]
+    public async Task CleanupOldImages_CurrentWallpaper_IsNotDeleted()
+    {
+        // Arrange: an expired file that is set as the current wallpaper but is NOT
+        // a favorite. Retention cleanup must skip it because deleting the active
+        // wallpaper would leave the desktop in an undefined state.
+        var source = new HttpWallpaperSourceService(NullLogger<HttpWallpaperSourceService>.Instance);
+        var sut = new DownloadWallpapers(NullLogger<DownloadWallpapers>.Instance, source);
+
+        var currentPath = Path.Combine(_downloadDir, "current.png");
+        TestHelpers.CreateSmallPng(currentPath);
+        File.SetLastWriteTimeUtc(currentPath, DateTime.UtcNow.AddDays(-400));
+
+        var settings = new WallpaperNexusSettings
+        {
+            Download = new DownloadSettings { Folder = _downloadDir, RetentionDays = 365 },
+            CurrentWallpaperPath = currentPath,
+        };
+
+        // Act
+        await sut.CleanupOldImages(settings);
+
+        // Assert: current wallpaper is preserved despite being past the retention cutoff
+        Assert.True(File.Exists(currentPath), "Current wallpaper should not be deleted by retention cleanup");
+    }
+
+    [Fact]
+    public async Task CleanupOldImages_ExpiredNonCurrentNonFavorite_IsStillDeleted()
+    {
+        // Arrange: two expired files — one is the current wallpaper, the other is not
+        // current and not favorited. Only the non-current file should be deleted.
+        var source = new HttpWallpaperSourceService(NullLogger<HttpWallpaperSourceService>.Instance);
+        var sut = new DownloadWallpapers(NullLogger<DownloadWallpapers>.Instance, source);
+
+        var currentPath = Path.Combine(_downloadDir, "current.png");
+        TestHelpers.CreateSmallPng(currentPath);
+        File.SetLastWriteTimeUtc(currentPath, DateTime.UtcNow.AddDays(-400));
+
+        var expiredPath = Path.Combine(_downloadDir, "expired.png");
+        TestHelpers.CreateSmallPng(expiredPath);
+        File.SetLastWriteTimeUtc(expiredPath, DateTime.UtcNow.AddDays(-400));
+
+        var settings = new WallpaperNexusSettings
+        {
+            Download = new DownloadSettings { Folder = _downloadDir, RetentionDays = 365 },
+            CurrentWallpaperPath = currentPath,
+        };
+
+        // Act
+        await sut.CleanupOldImages(settings);
+
+        // Assert: current wallpaper survives, non-current expired file is deleted
+        Assert.True(File.Exists(currentPath), "Current wallpaper should be preserved");
+        Assert.False(File.Exists(expiredPath), "Expired non-current file should be deleted");
+    }
+
     // Regression guard: CleanupOldImages must not throw when the wallpaper folder
     // has been deleted between DownloadFromSourcesAsync creating it and the cleanup step.
     // It should silently prune stale list entries and return without crashing.
@@ -437,6 +493,35 @@ public class DownloadWallpapersTests : IDisposable
         // Stale paths pointing to non-existent files must be pruned from both lists
         Assert.Empty(settings.FavoriteWallpapers);
         Assert.Empty(settings.BannedWallpapers);
+    }
+
+    // Regression guard: CleanupOldImages must not throw when CurrentWallpaperPath contains
+    // characters that cause Path.GetFullPath to throw (ArgumentException, NotSupportedException,
+    // or PathTooLongException). The try-catch must gracefully fall back so expired files are
+    // still deleted and the cleanup completes without crashing the scheduler.
+    [Fact]
+    public async Task CleanupOldImages_InvalidCurrentWallpaperPath_DoesNotThrow()
+    {
+        var source = new HttpWallpaperSourceService(NullLogger<HttpWallpaperSourceService>.Instance);
+        var sut = new DownloadWallpapers(NullLogger<DownloadWallpapers>.Instance, source);
+
+        var expiredPath = Path.Combine(_downloadDir, "expired.png");
+        TestHelpers.CreateSmallPng(expiredPath);
+        File.SetLastWriteTimeUtc(expiredPath, DateTime.UtcNow.AddDays(-400));
+
+        var settings = new WallpaperNexusSettings
+        {
+            Download = new DownloadSettings { Folder = _downloadDir, RetentionDays = 365 },
+            // Null byte triggers ArgumentException in Path.GetFullPath
+            CurrentWallpaperPath = "invalid:path\0chars",
+        };
+
+        // Act: should not throw despite the invalid CurrentWallpaperPath
+        var ex = await Record.ExceptionAsync(() => sut.CleanupOldImages(settings));
+
+        // Assert: cleanup completed without throwing and expired file was still deleted
+        Assert.Null(ex);
+        Assert.False(File.Exists(expiredPath), "Expired file should still be deleted when CurrentWallpaperPath is invalid");
     }
 
     [Fact]

--- a/PaperNexus.Tests/SwitchWallpaperTests.cs
+++ b/PaperNexus.Tests/SwitchWallpaperTests.cs
@@ -375,9 +375,9 @@ public class SwitchWallpaperTests : IAsyncLifetime, IDisposable
     {
         // Arrange: two wallpapers, one favorited with weight 10 (very high boost).
         // Over many iterations the favorite should win the overwhelming majority of picks.
-        var pathFav  = Path.Combine(_wallpaperDir, "favorite.png");
+        var pathFav = Path.Combine(_wallpaperDir, "favorite.png");
         var pathNorm = Path.Combine(_wallpaperDir, "normal.png");
-        TestHelpers.CreateSmallPng(pathFav,  r: 100);
+        TestHelpers.CreateSmallPng(pathFav, r: 100);
         TestHelpers.CreateSmallPng(pathNorm, r: 200);
         TestHelpers.Cleanup();
 
@@ -425,9 +425,9 @@ public class SwitchWallpaperTests : IAsyncLifetime, IDisposable
         // Arrange: two wallpapers, one favorited but priority is disabled.
         // Both files should appear as equals in the pool — the test verifies the
         // non-favorite also gets picked at least once over many iterations.
-        var pathFav  = Path.Combine(_wallpaperDir, "favorite.png");
+        var pathFav = Path.Combine(_wallpaperDir, "favorite.png");
         var pathNorm = Path.Combine(_wallpaperDir, "normal.png");
-        TestHelpers.CreateSmallPng(pathFav,  r: 100);
+        TestHelpers.CreateSmallPng(pathFav, r: 100);
         TestHelpers.CreateSmallPng(pathNorm, r: 200);
         TestHelpers.Cleanup();
 

--- a/PaperNexus/AutoUpdateService.cs
+++ b/PaperNexus/AutoUpdateService.cs
@@ -8,7 +8,7 @@ namespace PaperNexus;
 
 internal interface ICheckForUpdates
 {
-    Task CheckAsync(bool forceUpdate = false, IProgress<string>? progress = null);
+    public Task CheckAsync(bool forceUpdate = false, IProgress<string>? progress = null);
 }
 
 internal sealed class AutoUpdateService : ICheckForUpdates, IAddSingleton<ICheckForUpdates>

--- a/PaperNexus/Core/ScheduledService.cs
+++ b/PaperNexus/Core/ScheduledService.cs
@@ -31,8 +31,8 @@ public record JobConfig(
 
 public interface IScheduleScopedJob
 {
-    Task<JobConfig> GetJobConfigAsync();
-    Task ExecuteAsync();
+    public Task<JobConfig> GetJobConfigAsync();
+    public Task ExecuteAsync();
 }
 
 public abstract class ScheduledJobService : IHostedService, IDisposable

--- a/PaperNexus/DownloadWallpapers.cs
+++ b/PaperNexus/DownloadWallpapers.cs
@@ -8,7 +8,7 @@ namespace PaperNexus;
 
 internal interface IDownloadWallpapers
 {
-    Task DownloadAllAsync();
+    public Task DownloadAllAsync();
 }
 
 internal class DownloadWallpapers : ScheduledJobService, IDownloadWallpapers, IAddHostedSingleton<IDownloadWallpapers>
@@ -257,10 +257,11 @@ internal class DownloadWallpapers : ScheduledJobService, IDownloadWallpapers, IA
     }
 
     // Deletes wallpaper files older than the configured retention period and prunes
-    // stale paths from FavoriteWallpapers and BannedWallpapers. Favorited files are
-    // excluded from the age-based deletion but their paths are still pruned if the file
-    // no longer exists (e.g. manually deleted outside the app). The caller is responsible
-    // for saving settings after this method returns.
+    // stale paths from FavoriteWallpapers and BannedWallpapers. Favorited files and the
+    // currently active wallpaper (CurrentWallpaperPath) are excluded from the age-based
+    // deletion but their paths are still pruned if the file no longer exists (e.g.
+    // manually deleted outside the app). The caller is responsible for saving settings
+    // after this method returns.
     internal async Task CleanupOldImages(WallpaperNexusSettings settings)
     {
         // Guard against the folder being deleted between the Directory.CreateDirectory
@@ -276,6 +277,23 @@ internal class DownloadWallpapers : ScheduledJobService, IDownloadWallpapers, IA
         var favorites = new HashSet<string>(
             settings.FavoriteWallpapers ?? [],
             StringComparer.OrdinalIgnoreCase);
+        // Resolve the currently active wallpaper to a full path so the comparison
+        // against FileInfo.FullName is reliable regardless of relative vs absolute storage.
+        // Path.GetFullPath can throw for several reasons — invalid characters (ArgumentException),
+        // unsupported path format such as ":" in the wrong position (NotSupportedException),
+        // or exceeding MAX_PATH (PathTooLongException) — so fall back to empty (treat as unmatched).
+        var currentWallpaper = string.Empty;
+        if (!string.IsNullOrEmpty(settings.CurrentWallpaperPath))
+        {
+            try
+            {
+                currentWallpaper = Path.GetFullPath(settings.CurrentWallpaperPath);
+            }
+            catch (Exception ex) when (ex is ArgumentException or NotSupportedException or PathTooLongException)
+            {
+                Logger.LogWarning(ex, "CurrentWallpaperPath is invalid — ignoring for retention cleanup.");
+            }
+        }
         // Materialise the directory listing once so we can reuse it for the stale-path
         // check below without a second filesystem round-trip or a TOCTOU window.
         var allFiles = new DirectoryInfo(settings.Download.Folder).EnumerateFiles().ToList();
@@ -283,7 +301,9 @@ internal class DownloadWallpapers : ScheduledJobService, IDownloadWallpapers, IA
         var deleted = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
         foreach (var file in allFiles)
         {
-            if (cutoff > file.LastWriteTimeUtc && !favorites.Contains(file.FullName))
+            if (cutoff > file.LastWriteTimeUtc
+                && !favorites.Contains(file.FullName)
+                && !string.Equals(file.FullName, currentWallpaper, StringComparison.OrdinalIgnoreCase))
             {
                 file.Delete();
                 deleted.Add(file.FullName);

--- a/PaperNexus/SwitchWallpaper.cs
+++ b/PaperNexus/SwitchWallpaper.cs
@@ -15,10 +15,10 @@ namespace PaperNexus;
 
 public interface ISwitchWallpaper
 {
-    event Action<string>? WallpaperChanged;
-    Task<string?> SwitchToNextAsync();
-    Task<string?> SwitchToRandomAsync();
-    Task<string?> SwitchToSpecificAsync(string path);
+    public event Action<string>? WallpaperChanged;
+    public Task<string?> SwitchToNextAsync();
+    public Task<string?> SwitchToRandomAsync();
+    public Task<string?> SwitchToSpecificAsync(string path);
 }
 
 internal sealed class SwitchWallpaper : ISwitchWallpaper, IAddSingleton<ISwitchWallpaper>

--- a/PaperNexus/ViewModels/WallpaperConfigViewModel.cs
+++ b/PaperNexus/ViewModels/WallpaperConfigViewModel.cs
@@ -1254,11 +1254,11 @@ public partial class WallpaperConfigViewModel : ObservableObject
         {
             IntervalType.Seconds => $"*/{Math.Min(n, 59)} * * * * *",
             IntervalType.Minutes => $"*/{Math.Min(n, 59)} * * * *",
-            IntervalType.Hours   => $"0 */{Math.Min(n, 23)} * * *",
-            IntervalType.Days    => $"0 0 */{Math.Min(n, 28)} * *",
-            IntervalType.Weeks   => $"0 0 */{Math.Min(n * 7, 28)} * *",
-            IntervalType.Months  => $"0 0 1 */{Math.Min(n, 12)} *",
-            _                    => "0 0 1 1 *", // Years
+            IntervalType.Hours => $"0 */{Math.Min(n, 23)} * * *",
+            IntervalType.Days => $"0 0 */{Math.Min(n, 28)} * *",
+            IntervalType.Weeks => $"0 0 */{Math.Min(n * 7, 28)} * *",
+            IntervalType.Months => $"0 0 1 */{Math.Min(n, 12)} *",
+            _ => "0 0 1 1 *", // Years
         };
     }
 


### PR DESCRIPTION
## Summary

`CleanupOldImages` now skips the file referenced by `CurrentWallpaperPath`, preventing a broken state where wallpaper switching fails because the active wallpaper was deleted by age-based retention.

- Added `CurrentWallpaperPath` exclusion alongside existing favorites exclusion in the deletion loop
- Defensive exception handling around `Path.GetFullPath()` for corrupt settings paths
- 3 new unit tests covering protection, non-over-protection, and invalid path resilience

Closes #121

🤖 Claude Opus 4.6