### PR TITLE
fix: defensively dispose drawing resources in annotation rendering

### DIFF
--- a/PaperNexus.Tests/SwitchWallpaperTests.cs
+++ b/PaperNexus.Tests/SwitchWallpaperTests.cs
@@ -368,6 +368,43 @@ public class SwitchWallpaperTests : IAsyncLifetime, IDisposable
         Assert.Null(result);
     }
 
+    // --- Annotation rendering tests ---
+
+    [Fact]
+    public async Task SwitchToNext_AnnotationEnabled_ReturnsNonNull()
+    {
+        // Arrange: one wallpaper with annotation enabled and valid settings.
+        // Exercises the brush/pen creation and img.Clone annotation code path.
+        var wallpaperPath = Path.Combine(_wallpaperDir, "annotated - test.png");
+        TestHelpers.CreateSmallPng(wallpaperPath);
+        TestHelpers.Cleanup();
+
+        var settings = new WallpaperNexusSettings
+        {
+            Download = new DownloadSettings { Folder = _wallpaperDir },
+            Slideshow = new SlideshowSettings { Order = SlideshowOrder.Alphabetical, Enabled = false },
+            CurrentWallpaperPath = string.Empty,
+            Sources = [],
+            AnnotateWallpaper = true,
+            Annotation = new AnnotationSettings
+            {
+                FontSize = 18,
+                Color = "#F5F5F5",
+                Position = AnnotationPosition.TopLeft,
+                OutlineEnabled = true,
+            },
+        };
+        await settings.SaveAsync();
+
+        var switcher = new SwitchWallpaper(NullLogger<SwitchWallpaper>.Instance);
+
+        // Act
+        var result = await switcher.SwitchToNextAsync();
+
+        // Assert: annotation path should complete without error and return a valid wallpaper path
+        Assert.NotNull(result);
+    }
+
     // --- ApplyFavoritePriority / favorite weighting tests ---
 
     [Fact]

--- a/PaperNexus/SwitchWallpaper.cs
+++ b/PaperNexus/SwitchWallpaper.cs
@@ -228,6 +228,12 @@ internal sealed class SwitchWallpaper : ISwitchWallpaper, IAddSingleton<ISwitchW
                 }
             });
             annotatedOwned = true;
+
+            // Defensively dispose drawing resources (no-op today; activates if SixLabors adds IDisposable).
+            // Cast through object to bypass sealed-class compile-time check (CS0039).
+            (font as object as IDisposable)?.Dispose();
+            (brush as object as IDisposable)?.Dispose();
+            (outlinePen as object as IDisposable)?.Dispose();
         }
         else
         {


### PR DESCRIPTION
## Summary

Font, SolidBrush, and Pen created for wallpaper annotation are now defensively disposed after rendering. Uses `(obj as object as IDisposable)?.Dispose()` pattern — a no-op today that activates if SixLabors ever adds `IDisposable`.

- Defensive disposal for `font`, `brush`, and `outlinePen` after `img.Clone` completes
- New test `SwitchToNext_AnnotationEnabled_ReturnsNonNull` exercises annotation code path

Closes #125

🤖 Claude Opus 4.6