### PR TITLE
refactor: extract IWallpaperApplier to isolate tests from Windows API

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -126,3 +126,4 @@ Enforced via `.editorconfig`: .NET 10, C#, file-scoped namespaces, 4-space inden
 - **Branch protection on `main`:** PRs required, `build` status check required, `enforce_admins: true` (owner cannot bypass)
 - **Always start work on a feature branch** — never commit directly to `main`; create a descriptive branch (e.g., `feature/wallpaper-preview`, `fix/auto-update`) before making any changes
 - **Comment addition tasks:** Add comments in small, focused batches (1–3 files at a time) rather than delegating all files to a single agent. Large batches risk code corruption.
+- **No system-level calls in unit tests:** Tests must never invoke real OS APIs (e.g., `NativeMethods`, registry writes, `SetDesktopWallpaper`). Use injectable interfaces with no-op test doubles (e.g., `NoOpWallpaperApplier`) to isolate from the system.

--- a/PaperNexus.Tests/RefreshPreviewImageTests.cs
+++ b/PaperNexus.Tests/RefreshPreviewImageTests.cs
@@ -85,7 +85,7 @@ public class RefreshPreviewImageTests : IAsyncLifetime, IDisposable
         File.WriteAllBytes(TestHelpers.JpgPath, [0xFF, 0xD8, 0xFF]);
         await TestHelpers.WriteSettingsAsync(_wallpaperDir);
 
-        var switcher = new SwitchWallpaper(NullLogger<SwitchWallpaper>.Instance);
+        var switcher = new SwitchWallpaper(NullLogger<SwitchWallpaper>.Instance, NoOpWallpaperApplier.Instance);
         var vm = new WallpaperConfigViewModel();
 
         // Act: switch wallpaper, then refresh preview (simulates window reopen)

--- a/PaperNexus.Tests/SwitchWallpaperTests.cs
+++ b/PaperNexus.Tests/SwitchWallpaperTests.cs
@@ -4,6 +4,14 @@ using Xunit;
 
 namespace PaperNexus.Tests;
 
+// No-op implementation so tests don't call the real Windows API
+internal sealed class NoOpWallpaperApplier : IWallpaperApplier
+{
+    public static readonly NoOpWallpaperApplier Instance = new();
+    public bool SetWallpaper(string wallpaperPath) => true;
+    public void ApplyFillStyle(WallpaperFillStyle style) { }
+}
+
 [Collection("Wallpaper")]
 public class SwitchWallpaperTests : IAsyncLifetime, IDisposable
 {
@@ -38,7 +46,7 @@ public class SwitchWallpaperTests : IAsyncLifetime, IDisposable
         File.WriteAllBytes(TestHelpers.JpgPath, [0xFF, 0xD8, 0xFF]); // fake JPEG marker
         await TestHelpers.WriteSettingsAsync(_wallpaperDir);
 
-        var switcher = new SwitchWallpaper(NullLogger<SwitchWallpaper>.Instance);
+        var switcher = new SwitchWallpaper(NullLogger<SwitchWallpaper>.Instance, NoOpWallpaperApplier.Instance);
 
         // Act
         var result = await switcher.SwitchToNextAsync();
@@ -58,7 +66,7 @@ public class SwitchWallpaperTests : IAsyncLifetime, IDisposable
         File.WriteAllBytes(TestHelpers.PngPath, [0x89, 0x50, 0x4E, 0x47]); // fake PNG marker
         await TestHelpers.WriteSettingsAsync(_wallpaperDir);
 
-        var switcher = new SwitchWallpaper(NullLogger<SwitchWallpaper>.Instance);
+        var switcher = new SwitchWallpaper(NullLogger<SwitchWallpaper>.Instance, NoOpWallpaperApplier.Instance);
 
         // Act
         var result = await switcher.SwitchToNextAsync();
@@ -78,7 +86,7 @@ public class SwitchWallpaperTests : IAsyncLifetime, IDisposable
         TestHelpers.Cleanup(); // ensure no current.png/jpg
         await TestHelpers.WriteSettingsAsync(_wallpaperDir);
 
-        var switcher = new SwitchWallpaper(NullLogger<SwitchWallpaper>.Instance);
+        var switcher = new SwitchWallpaper(NullLogger<SwitchWallpaper>.Instance, NoOpWallpaperApplier.Instance);
 
         // Act
         var result = await switcher.SwitchToNextAsync();
@@ -98,7 +106,7 @@ public class SwitchWallpaperTests : IAsyncLifetime, IDisposable
         var missingFolder = Path.Combine(Path.GetTempPath(), $"PaperNexus_Missing_{Guid.NewGuid():N}");
         await TestHelpers.WriteSettingsAsync(missingFolder);
 
-        var switcher = new SwitchWallpaper(NullLogger<SwitchWallpaper>.Instance);
+        var switcher = new SwitchWallpaper(NullLogger<SwitchWallpaper>.Instance, NoOpWallpaperApplier.Instance);
 
         // Act — should not throw DirectoryNotFoundException
         var result = await switcher.SwitchToNextAsync();
@@ -123,7 +131,7 @@ public class SwitchWallpaperTests : IAsyncLifetime, IDisposable
         };
         await settings.SaveAsync();
 
-        var switcher = new SwitchWallpaper(NullLogger<SwitchWallpaper>.Instance);
+        var switcher = new SwitchWallpaper(NullLogger<SwitchWallpaper>.Instance, NoOpWallpaperApplier.Instance);
 
         // Act
         var result = await switcher.SwitchToNextAsync();
@@ -157,7 +165,7 @@ public class SwitchWallpaperTests : IAsyncLifetime, IDisposable
         };
         await settings.SaveAsync();
 
-        var switcher = new SwitchWallpaper(NullLogger<SwitchWallpaper>.Instance);
+        var switcher = new SwitchWallpaper(NullLogger<SwitchWallpaper>.Instance, NoOpWallpaperApplier.Instance);
 
         // Act
         var result = await switcher.SwitchToNextAsync();
@@ -190,7 +198,7 @@ public class SwitchWallpaperTests : IAsyncLifetime, IDisposable
         };
         await settings.SaveAsync();
 
-        var switcher = new SwitchWallpaper(NullLogger<SwitchWallpaper>.Instance);
+        var switcher = new SwitchWallpaper(NullLogger<SwitchWallpaper>.Instance, NoOpWallpaperApplier.Instance);
 
         // Act
         var result = await switcher.SwitchToNextAsync();
@@ -224,7 +232,7 @@ public class SwitchWallpaperTests : IAsyncLifetime, IDisposable
         };
         await settings.SaveAsync();
 
-        var switcher = new SwitchWallpaper(NullLogger<SwitchWallpaper>.Instance);
+        var switcher = new SwitchWallpaper(NullLogger<SwitchWallpaper>.Instance, NoOpWallpaperApplier.Instance);
 
         // Act
         var result = await switcher.SwitchToNextAsync();
@@ -242,7 +250,7 @@ public class SwitchWallpaperTests : IAsyncLifetime, IDisposable
         var missingFolder = Path.Combine(Path.GetTempPath(), $"PaperNexus_Missing_{Guid.NewGuid():N}");
         await TestHelpers.WriteSettingsAsync(missingFolder);
 
-        var switcher = new SwitchWallpaper(NullLogger<SwitchWallpaper>.Instance);
+        var switcher = new SwitchWallpaper(NullLogger<SwitchWallpaper>.Instance, NoOpWallpaperApplier.Instance);
 
         var result = await switcher.SwitchToRandomAsync();
 
@@ -264,7 +272,7 @@ public class SwitchWallpaperTests : IAsyncLifetime, IDisposable
         };
         await settings.SaveAsync();
 
-        var switcher = new SwitchWallpaper(NullLogger<SwitchWallpaper>.Instance);
+        var switcher = new SwitchWallpaper(NullLogger<SwitchWallpaper>.Instance, NoOpWallpaperApplier.Instance);
 
         var result = await switcher.SwitchToRandomAsync();
 
@@ -292,7 +300,7 @@ public class SwitchWallpaperTests : IAsyncLifetime, IDisposable
         };
         await settings.SaveAsync();
 
-        var switcher = new SwitchWallpaper(NullLogger<SwitchWallpaper>.Instance);
+        var switcher = new SwitchWallpaper(NullLogger<SwitchWallpaper>.Instance, NoOpWallpaperApplier.Instance);
 
         // Act: run many times to ensure randomness never returns the current wallpaper
         for (var i = 0; i < 10; i++)
@@ -327,7 +335,7 @@ public class SwitchWallpaperTests : IAsyncLifetime, IDisposable
         };
         await settings.SaveAsync();
 
-        var switcher = new SwitchWallpaper(NullLogger<SwitchWallpaper>.Instance);
+        var switcher = new SwitchWallpaper(NullLogger<SwitchWallpaper>.Instance, NoOpWallpaperApplier.Instance);
 
         var result = await switcher.SwitchToRandomAsync();
 
@@ -345,7 +353,7 @@ public class SwitchWallpaperTests : IAsyncLifetime, IDisposable
         TestHelpers.Cleanup();
         await TestHelpers.WriteSettingsAsync(_wallpaperDir);
 
-        var switcher = new SwitchWallpaper(NullLogger<SwitchWallpaper>.Instance);
+        var switcher = new SwitchWallpaper(NullLogger<SwitchWallpaper>.Instance, NoOpWallpaperApplier.Instance);
 
         var result = await switcher.SwitchToSpecificAsync(wallpaperPath);
 
@@ -361,7 +369,7 @@ public class SwitchWallpaperTests : IAsyncLifetime, IDisposable
         TestHelpers.Cleanup();
         await TestHelpers.WriteSettingsAsync(_wallpaperDir);
 
-        var switcher = new SwitchWallpaper(NullLogger<SwitchWallpaper>.Instance);
+        var switcher = new SwitchWallpaper(NullLogger<SwitchWallpaper>.Instance, NoOpWallpaperApplier.Instance);
 
         var result = await switcher.SwitchToSpecificAsync(missingPath);
 
@@ -396,7 +404,7 @@ public class SwitchWallpaperTests : IAsyncLifetime, IDisposable
         };
         await settings.SaveAsync();
 
-        var switcher = new SwitchWallpaper(NullLogger<SwitchWallpaper>.Instance);
+        var switcher = new SwitchWallpaper(NullLogger<SwitchWallpaper>.Instance, NoOpWallpaperApplier.Instance);
 
         // Act
         var result = await switcher.SwitchToNextAsync();
@@ -434,7 +442,7 @@ public class SwitchWallpaperTests : IAsyncLifetime, IDisposable
             AnnotateWallpaper = false,
         };
 
-        var switcher = new SwitchWallpaper(NullLogger<SwitchWallpaper>.Instance);
+        var switcher = new SwitchWallpaper(NullLogger<SwitchWallpaper>.Instance, NoOpWallpaperApplier.Instance);
         var favoritePicks = 0;
         const int iterations = 50;
 
@@ -483,7 +491,7 @@ public class SwitchWallpaperTests : IAsyncLifetime, IDisposable
             AnnotateWallpaper = false,
         };
 
-        var switcher = new SwitchWallpaper(NullLogger<SwitchWallpaper>.Instance);
+        var switcher = new SwitchWallpaper(NullLogger<SwitchWallpaper>.Instance, NoOpWallpaperApplier.Instance);
         var normalPicks = 0;
         const int iterations = 40;
 

--- a/PaperNexus/NativeMethods.cs
+++ b/PaperNexus/NativeMethods.cs
@@ -1,6 +1,43 @@
 using System.Runtime.InteropServices;
+using Microsoft.Win32;
+using PaperNexus.Core;
 
 namespace PaperNexus;
+
+// Abstraction over Windows desktop API calls so tests can run without changing the real wallpaper
+public interface IWallpaperApplier
+{
+    public bool SetWallpaper(string wallpaperPath);
+    public void ApplyFillStyle(WallpaperFillStyle style);
+}
+
+internal sealed class WallpaperApplier : IWallpaperApplier, IAddSingleton<IWallpaperApplier>
+{
+    public bool SetWallpaper(string wallpaperPath) => NativeMethods.SetDesktopWallpaper(wallpaperPath);
+
+    public void ApplyFillStyle(WallpaperFillStyle style)
+    {
+        if (!OperatingSystem.IsWindows())
+            return;
+
+        // WallpaperStyle and TileWallpaper registry values under HKCU\Control Panel\Desktop
+        // control how Windows positions the wallpaper image.
+        var (wallpaperStyle, tileWallpaper) = style switch
+        {
+            WallpaperFillStyle.Tile => ("0", "1"),
+            WallpaperFillStyle.Center => ("0", "0"),
+            WallpaperFillStyle.Stretch => ("2", "0"),
+            WallpaperFillStyle.Fit => ("6", "0"),
+            WallpaperFillStyle.Fill => ("10", "0"),
+            WallpaperFillStyle.Span => ("22", "0"),
+            _ => ("10", "0"),
+        };
+
+        using var key = Registry.CurrentUser.OpenSubKey(@"Control Panel\Desktop", writable: true);
+        key?.SetValue("WallpaperStyle", wallpaperStyle);
+        key?.SetValue("TileWallpaper", tileWallpaper);
+    }
+}
 
 internal static class NativeMethods
 {

--- a/PaperNexus/SwitchWallpaper.cs
+++ b/PaperNexus/SwitchWallpaper.cs
@@ -1,6 +1,5 @@
 using Cronos;
 using PaperNexus.Core;
-using Microsoft.Win32;
 using SixLabors.Fonts;
 using BundledFonts = PaperNexus.Core.BundledFonts;
 using SixLabors.ImageSharp;
@@ -9,7 +8,6 @@ using SixLabors.ImageSharp.PixelFormats;
 using SixLabors.ImageSharp.Formats.Jpeg;
 using SixLabors.ImageSharp.Formats.Png;
 using SixLabors.ImageSharp.Processing;
-using System.Runtime.InteropServices;
 
 namespace PaperNexus;
 
@@ -24,12 +22,14 @@ public interface ISwitchWallpaper
 internal sealed class SwitchWallpaper : ISwitchWallpaper, IAddSingleton<ISwitchWallpaper>
 {
     private readonly ILogger<SwitchWallpaper> _logger;
+    private readonly IWallpaperApplier _wallpaperApplier;
 
     public event Action<string>? WallpaperChanged;
 
-    public SwitchWallpaper(ILogger<SwitchWallpaper> logger)
+    public SwitchWallpaper(ILogger<SwitchWallpaper> logger, IWallpaperApplier wallpaperApplier)
     {
         _logger = logger.ThrowIfNull();
+        _wallpaperApplier = wallpaperApplier.ThrowIfNull();
     }
 
     // Advances to the next wallpaper according to the configured slideshow order.
@@ -275,10 +275,9 @@ internal sealed class SwitchWallpaper : ISwitchWallpaper, IAddSingleton<ISwitchW
                 File.Delete(Path.Combine(AppContext.BaseDirectory, "current.png"));
             }
 
-            if (OperatingSystem.IsWindows())
-                ApplyFillStyle(settings.Slideshow.FillStyle);
+            _wallpaperApplier.ApplyFillStyle(settings.Slideshow.FillStyle);
             // Log a warning if the Win32 API call reports failure so silent wallpaper-not-set bugs surface in logs
-            var wallpaperSet = NativeMethods.SetDesktopWallpaper(currentPath);
+            var wallpaperSet = _wallpaperApplier.SetWallpaper(currentPath);
             if (!wallpaperSet)
                 _logger.LogWarning("SystemParametersInfo(SPI_SETDESKWALLPAPER) returned 0 for path: {Path}", currentPath);
             _logger.LogInformation("Switching wallpaper to: {Path}", next);
@@ -300,26 +299,6 @@ internal sealed class SwitchWallpaper : ISwitchWallpaper, IAddSingleton<ISwitchW
 
     private const long SizeCeiling = 1 << 24; // 16 MB
 
-    [System.Runtime.Versioning.SupportedOSPlatform("windows")]
-    private static void ApplyFillStyle(WallpaperFillStyle style)
-    {
-        // WallpaperStyle and TileWallpaper registry values under HKCU\Control Panel\Desktop
-        // control how Windows positions the wallpaper image.
-        var (wallpaperStyle, tileWallpaper) = style switch
-        {
-            WallpaperFillStyle.Tile => ("0", "1"),
-            WallpaperFillStyle.Center => ("0", "0"),
-            WallpaperFillStyle.Stretch => ("2", "0"),
-            WallpaperFillStyle.Fit => ("6", "0"),
-            WallpaperFillStyle.Fill => ("10", "0"),
-            WallpaperFillStyle.Span => ("22", "0"),
-            _ => ("10", "0"),
-        };
-
-        using var key = Registry.CurrentUser.OpenSubKey(@"Control Panel\Desktop", writable: true);
-        key?.SetValue("WallpaperStyle", wallpaperStyle);
-        key?.SetValue("TileWallpaper", tileWallpaper);
-    }
 }
 
 internal sealed class SwitchWallpaperJob : IScheduleScopedJob


### PR DESCRIPTION
## Summary

SwitchWallpaper tests were calling `NativeMethods.SetDesktopWallpaper` and writing registry fill-style values on every run, flickering the desktop and corrupting the wallpaper registry entry.

- Extracted `IWallpaperApplier` interface wrapping `SetWallpaper` and `ApplyFillStyle`
- `WallpaperApplier` implements it with the real P/Invoke + registry calls, registered via `IAddSingleton`
- Injected into `SwitchWallpaper` constructor
- Tests use `NoOpWallpaperApplier.Instance` — no more system side effects
- Added CLAUDE.md guideline: no system-level calls in unit tests

## Test plan
- [x] All 103 tests pass with no desktop flickering
- [x] Build succeeds with no new warnings
- [x] DI auto-discovery still registers `WallpaperApplier` via `IAddSingleton<IWallpaperApplier>`

🤖 Generated with [Claude Code](https://claude.com/claude-code)