### PR TITLE
fix: capture retry result in tray menu wallpaper switch handlers

### DIFF
--- a/PaperNexus/App.axaml.cs
+++ b/PaperNexus/App.axaml.cs
@@ -155,9 +155,11 @@ public partial class App : Application
                     if (downloader is not null)
                     {
                         await Task.Run(downloader.DownloadAllAsync);
-                        await Task.Run(switcher.SwitchToNextAsync);
+                        next = await Task.Run(switcher.SwitchToNextAsync);
                     }
                 }
+                if (next is null)
+                    Logger?.LogWarning("Tray 'Next Wallpaper' failed: no wallpapers available after download retry.");
             }
             catch (Exception ex)
             {
@@ -187,9 +189,11 @@ public partial class App : Application
                     if (downloader is not null)
                     {
                         await Task.Run(downloader.DownloadAllAsync);
-                        await Task.Run(switcher.SwitchToRandomAsync);
+                        next = await Task.Run(switcher.SwitchToRandomAsync);
                     }
                 }
+                if (next is null)
+                    Logger?.LogWarning("Tray 'Random Wallpaper' failed: no wallpapers available after download retry.");
             }
             catch (Exception ex)
             {


### PR DESCRIPTION
## Summary

Next/Random tray menu items discarded the return value of the retry switch after downloading, causing silent failures when no wallpapers were available. Now captures the result into `next` and logs a warning when the retry also returns null.

- `next =` added to retry calls on lines 158 and 192
- Warning logged when both initial and retry switch return null

Closes #128

🤖 Claude Opus 4.6