### PR TITLE
fix(ci): use stdin pipe for gh secret set password command

### DIFF
--- a/.github/workflows/deploy-wallpaper-service.yml
+++ b/.github/workflows/deploy-wallpaper-service.yml
@@ -84,7 +84,7 @@ jobs:
 
           if [[ -n "$GH_TOKEN" ]]; then
             base64 -w0 "$pfxPath" | gh secret set SIGNING_CERTIFICATE --repo '${{ github.repository }}'
-            gh secret set SIGNING_CERTIFICATE_PASSWORD --body "$certPassword" --repo '${{ github.repository }}'
+            echo "$certPassword" | gh secret set SIGNING_CERTIFICATE_PASSWORD --repo '${{ github.repository }}'
             echo "Signing certificate generated and stored as repository secrets."
           else
             echo "WARNING: GH_PAT not set — cert is ephemeral for this run. Add a GH_PAT secret (secrets:write) to persist it."


### PR DESCRIPTION
## Summary

Line 87 in the deploy workflow used the non-existent `--body` flag for `gh secret set`, preventing the signing certificate password from being persisted to repository secrets. Now pipes via stdin, matching the pattern on line 86.

Closes #130

🤖 Claude Opus 4.6