### PR TITLE
feat(platform): add first-class Linux support

### DIFF
--- a/.github/workflows/deploy-wallpaper-service.yml
+++ b/.github/workflows/deploy-wallpaper-service.yml
@@ -12,11 +12,22 @@ permissions:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, Linux, X64]
 
     steps:
     - name: Checkout code
       uses: actions/checkout@v6
+
+    # The self-hosted runner has no system-wide .NET software development kit,
+    # and the unprivileged runner user cannot create the default /usr/share/dotnet
+    # install location. Installing into the runner tool cache is both writable and
+    # persistent, so the download happens once and is reused by later runs.
+    - name: Set up .NET
+      uses: actions/setup-dotnet@v5
+      with:
+        dotnet-version: '10.0.x'
+      env:
+        DOTNET_INSTALL_DIR: ${{ runner.tool_cache }}/dotnet
 
     - name: Restore dependencies
       run: dotnet restore
@@ -51,8 +62,17 @@ jobs:
         mv ./publish/linux-x64/PaperNexus ./publish/linux-x64/PaperNexus-linux-x64
         chmod +x ./publish/linux-x64/PaperNexus-linux-x64
 
+    # The self-hosted runner persists between runs, so osslsigncode survives from
+    # the run that installed it. Installing unconditionally would re-run apt on
+    # every build and fail outright on a runner whose user has no sudo rights.
     - name: Install signing tools
-      run: sudo apt-get install -y osslsigncode
+      run: |
+        if command -v osslsigncode >/dev/null 2>&1; then
+          echo "osslsigncode already present: $(command -v osslsigncode)"
+          exit 0
+        fi
+        sudo apt-get update
+        sudo apt-get install -y osslsigncode
 
     - name: Sign executable (self-signed)
       env:

--- a/.github/workflows/deploy-wallpaper-service.yml
+++ b/.github/workflows/deploy-wallpaper-service.yml
@@ -33,15 +33,23 @@ jobs:
         else
           buildNum="$runNumber"
         fi
-        dotnet publish PaperNexus/PaperNexus.csproj \
-          --configuration Release \
-          --runtime win-x64 \
-          --self-contained true \
-          -p:PublishSingleFile=true \
-          -p:IncludeNativeLibrariesForSelfExtract=true \
-          -p:PublishTrimmed=false \
-          -p:Version="$buildNum.0.0" \
-          --output ./publish/PaperNexus
+
+        # One single-file, self-contained binary per supported platform.
+        for rid in win-x64 linux-x64; do
+          dotnet publish PaperNexus/PaperNexus.csproj \
+            --configuration Release \
+            --runtime "$rid" \
+            --self-contained true \
+            -p:PublishSingleFile=true \
+            -p:IncludeNativeLibrariesForSelfExtract=true \
+            -p:PublishTrimmed=false \
+            -p:Version="$buildNum.0.0" \
+            --output "./publish/$rid"
+        done
+
+        # The auto-updater looks the Linux asset up by this exact name.
+        mv ./publish/linux-x64/PaperNexus ./publish/linux-x64/PaperNexus-linux-x64
+        chmod +x ./publish/linux-x64/PaperNexus-linux-x64
 
     - name: Install signing tools
       run: sudo apt-get install -y osslsigncode
@@ -96,10 +104,16 @@ jobs:
           -pass "$certPassword" \
           -h sha256 \
           -t http://timestamp.digicert.com \
-          -in ./publish/PaperNexus/PaperNexus.exe \
-          -out ./publish/PaperNexus/PaperNexus-signed.exe
-        mv ./publish/PaperNexus/PaperNexus-signed.exe ./publish/PaperNexus/PaperNexus.exe
+          -in ./publish/win-x64/PaperNexus.exe \
+          -out ./publish/win-x64/PaperNexus-signed.exe
+        mv ./publish/win-x64/PaperNexus-signed.exe ./publish/win-x64/PaperNexus.exe
         rm -f "$pfxPath"
+
+    # Authenticode is a PE-only format, so the Linux build's integrity is published as a
+    # SHA-256 digest instead. The auto-updater refuses any Linux update without this file.
+    - name: Checksum Linux binary
+      working-directory: ./publish/linux-x64
+      run: sha256sum PaperNexus-linux-x64 > PaperNexus-linux-x64.sha256
 
     - name: Create GitHub Release
       env:
@@ -138,7 +152,9 @@ jobs:
         gh release create "$newTag" \
           --title "Paper Nexus $newTag" \
           --notes "$notes" \
-          ./publish/PaperNexus/PaperNexus.exe
+          ./publish/win-x64/PaperNexus.exe \
+          ./publish/linux-x64/PaperNexus-linux-x64 \
+          ./publish/linux-x64/PaperNexus-linux-x64.sha256
         echo "NEW_TAG=$newTag" >> "$GITHUB_ENV"
 
     - name: Delete previous releases

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -9,11 +9,22 @@ permissions:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, Linux, X64]
 
     steps:
     - name: Checkout code
       uses: actions/checkout@v6
+
+    # The self-hosted runner has no system-wide .NET software development kit,
+    # and the unprivileged runner user cannot create the default /usr/share/dotnet
+    # install location. Installing into the runner tool cache is both writable and
+    # persistent, so the download happens once and is reused by later runs.
+    - name: Set up .NET
+      uses: actions/setup-dotnet@v5
+      with:
+        dotnet-version: '10.0.x'
+      env:
+        DOTNET_INSTALL_DIR: ${{ runner.tool_cache }}/dotnet
 
     - name: Restore dependencies
       run: dotnet restore

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,7 +2,7 @@
 
 ## Project Overview
 
-.NET 10.0 Avalonia desktop app for automated wallpaper rotation on Windows. Solution: `PaperNexus.sln`.
+.NET 10.0 Avalonia desktop app for automated wallpaper rotation on Windows and Linux. Solution: `PaperNexus.sln`.
 
 ## Quick Reference
 
@@ -31,7 +31,8 @@ PaperNexus/
 │       ├── pull-request.yml             # PR build verification
 │       └── deploy-wallpaper-service.yml # Release builds + code signing
 ├── docs/
-│   └── ui-style-guide.md               # Avalonia AXAML patterns reference
+│   ├── ui-style-guide.md               # Avalonia AXAML patterns reference
+│   └── platform-support.md             # Windows/Linux platform layer reference
 ├── PaperNexus.Tests/                    # Unit tests (xUnit + NSubstitute)
 └── PaperNexus/                          # Main project
     ├── PaperNexus.csproj
@@ -44,6 +45,14 @@ PaperNexus/
     ├── SwitchWallpaper.cs               # Wallpaper switching logic + job wrapper
     ├── Assets/                          # logo.ico, logo.png, bundled fonts
     ├── Core/                            # DI, logging, scheduling, settings
+    │   ├── Platform/                   # All Windows/Linux differences live here
+    │   │   ├── PlatformPaths.cs        # Executable name, install dir, path comparison
+    │   │   ├── SingleInstance.cs       # Mutex+event (Windows) / Unix socket (Linux)
+    │   │   ├── StartupRegistration.cs  # Run key (Windows) / XDG autostart (Linux)
+    │   │   ├── IWallpaperBackend.cs    # Per-OS wallpaper backend contract
+    │   │   ├── LinuxWallpaperBackend.cs # KDE / GNOME / feh-xwallpaper-swaybg
+    │   │   ├── LinuxDesktop.cs         # Desktop detection + helper process runner
+    │   │   └── ShellOpener.cs          # explorer.exe / xdg-open, app relaunch
     │   ├── Bootstrapper.cs             # DI helpers, IAddSingleton<T>, AddServicesFrom()
     │   ├── Extensions.cs               # Utility extension methods
     │   ├── FileLogger.cs               # File-based ILogger implementation (async queue)
@@ -65,7 +74,8 @@ PaperNexus/
 - **Scheduled Jobs (preferred):** `IScheduleScopedJob` — separate business logic from scheduling. Job wrapper delegates to injected interface. Auto-discovered by `AddServicesFrom()`.
 - **Scheduled Jobs (legacy):** `ScheduledJobService` base class — `DownloadWallpapers` extends directly. Registered via `IAddHostedSingleton<T>`.
 - **DI:** `AddServicesFrom(assembly)` auto-discovers `IAddSingleton<T>`, `IAddHostedSingleton<T>`, and `IScheduleScopedJob` implementations.
-- **Auto-Update:** Queries GitHub Releases API, compares `vN` tag as integer against `Assembly.Version.Major`, downloads exe, swaps via self-deleting batch script with rollback.
+- **Platform Layer (`Core/Platform/`):** Every Windows/Linux difference is isolated here - no other file may call a Windows-only API, hardcode `.exe`, or compare paths case-insensitively. See `docs/platform-support.md`.
+- **Auto-Update:** Queries GitHub Releases API, compares `vN` tag as integer against `Assembly.Version.Major`, downloads the per-platform asset (`PaperNexus.exe` / `PaperNexus-linux-x64`), verifies it (Authenticode on Windows, published SHA-256 on Linux), swaps via self-deleting script (`.bat` / `.sh`) with rollback.
 - **Auto-Install:** First run copies exe to the chosen install directory (default `%LOCALAPPDATA%\PaperNexus\`), migrates settings, writes a `.installed` sentinel file alongside the exe, then relaunches. On subsequent launches, `IsRunningFromInstallLocation` detects the sentinel file so custom install paths (not equal to the default AppData path) are recognised correctly and the install flow is not re-triggered.
 - **Single Instance:** Named `Mutex` + `EventWaitHandle` for IPC (signals running instance to show UI).
 - **Tray-only:** `ShutdownMode.OnExplicitShutdown`. Menu: "Open Settings", "Next Wallpaper", "Random Wallpaper", "Exit". Each item has a programmatically-drawn SixLabors icon.
@@ -74,7 +84,8 @@ PaperNexus/
 - **Wallpaper Sources (JPath-based):** `HttpWallpaperSourceService` uses Newtonsoft `SelectTokens` with `ImageUrlJPath`/`TitleJPath`. Sources edited via `WallpaperSourceDialog` (name, URL, JPath, cron, enabled toggle, live Test button).
 - **`NonScrollableComboBox`:** Suppresses scroll wheel unless dropdown is open — prevents accidental changes while scrolling the settings page.
 - **Favorites:** Heart toggle, stored in `settings.json`, excluded from retention cleanup.
-- **Windows Startup:** Registry key at `HKCU\...\Run\PaperNexus`.
+- **Startup at login:** Registry key at `HKCU\...\Run\PaperNexus` on Windows; `~/.config/autostart/PaperNexus.desktop` on Linux.
+- **Wallpaper on Linux:** No cross-desktop API - dispatches to KDE Plasma (`evaluateScript` over D-Bus), GNOME (`gsettings`), or `feh`/`xwallpaper`/`swaybg`. SteamOS Desktop Mode (KDE Plasma) is the Linux deployment target.
 
 ## Dependencies
 
@@ -108,7 +119,7 @@ Enforced via `.editorconfig`: .NET 10, C#, file-scoped namespaces, 4-space inden
 ## Build & CI/CD
 
 - **PR workflow:** restore → build (Release) → test (continue-on-error). `ubuntu-latest`, `actions/checkout@v6`.
-- **Deploy workflow:** push to `main`/tags/manual → publish win-x64 single-file → sign exe → GitHub Release. `ubuntu-latest`; signing uses `openssl` + `osslsigncode` (Linux equivalents of `New-SelfSignedCertificate`/`signtool.exe`).
+- **Deploy workflow:** push to `main`/tags/manual → publish win-x64 and linux-x64 single-file → sign the exe, checksum the Linux binary → GitHub Release with three assets. `ubuntu-latest`; signing uses `openssl` + `osslsigncode` (Linux equivalents of `New-SelfSignedCertificate`/`signtool.exe`).
 - **Version:** Default `0.0.0`, CI sets `-p:Version=$buildNum.0.0`. Tags use `vN` format. Auto-updater compares `Version.Major` as integer.
 - **Code signing:** Self-signed cert, auto-generated on first run, stored as `SIGNING_CERTIFICATE`/`SIGNING_CERTIFICATE_PASSWORD` secrets. Requires `GH_PAT` for persistence. 5-year validity, auto-renews at 30 days remaining.
 - **Publishing:** `dotnet publish PaperNexus/PaperNexus.csproj -c Release -r win-x64 --self-contained true -p:PublishSingleFile=true -p:IncludeNativeLibrariesForSelfExtract=true -p:PublishTrimmed=false`
@@ -117,6 +128,7 @@ Enforced via `.editorconfig`: .NET 10, C#, file-scoped namespaces, 4-space inden
 ## Guidelines
 
 - .NET 10.0, Avalonia UI (not WPF), root namespace `PaperNexus` / `PaperNexus.Core`
+- **Platform differences go in `Core/Platform/`** - read `docs/platform-support.md` before touching wallpaper setting, startup registration, single-instance, install/update paths, or any path comparison
 - AXAML assets: `avares://PaperNexus/Assets/...`
 - New scheduled jobs: use `IScheduleScopedJob` pattern, not `ScheduledJobService`
 - Never commit secrets. Check `dotnet list package --vulnerable`.
@@ -126,4 +138,5 @@ Enforced via `.editorconfig`: .NET 10, C#, file-scoped namespaces, 4-space inden
 - **Branch protection on `main`:** PRs required, `build` status check required, `enforce_admins: true` (owner cannot bypass)
 - **Always start work on a feature branch** — never commit directly to `main`; create a descriptive branch (e.g., `feature/wallpaper-preview`, `fix/auto-update`) before making any changes
 - **Comment addition tasks:** Add comments in small, focused batches (1–3 files at a time) rather than delegating all files to a single agent. Large batches risk code corruption.
+- **Verify Linux changes against the real desktop**, not the app log - read the desktop's own state (e.g. `gsettings get org.gnome.desktop.background picture-uri`). Setup is in `docs/platform-support.md`.
 - **No system-level calls in unit tests:** Tests must never invoke real OS APIs (e.g., `NativeMethods`, registry writes, `SetDesktopWallpaper`). Use injectable interfaces with no-op test doubles (e.g., `NoOpWallpaperApplier`) to isolate from the system.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -118,11 +118,12 @@ Enforced via `.editorconfig`: .NET 10, C#, file-scoped namespaces, 4-space inden
 
 ## Build & CI/CD
 
-- **PR workflow:** restore → build (Release) → test (continue-on-error). `ubuntu-latest`, `actions/checkout@v6`.
-- **Deploy workflow:** push to `main`/tags/manual → publish win-x64 and linux-x64 single-file → sign the exe, checksum the Linux binary → GitHub Release with three assets. `ubuntu-latest`; signing uses `openssl` + `osslsigncode` (Linux equivalents of `New-SelfSignedCertificate`/`signtool.exe`).
+- **PR workflow:** set up .NET → restore → build (Release) → test (continue-on-error). Self-hosted runner (`[self-hosted, Linux, X64]`), `actions/checkout@v6`.
+- **Deploy workflow:** push to `main`/tags/manual → publish win-x64 and linux-x64 single-file → sign the exe, checksum the Linux binary → GitHub Release with three assets. Self-hosted runner (`[self-hosted, Linux, X64]`); signing uses `openssl` + `osslsigncode` (Linux equivalents of `New-SelfSignedCertificate`/`signtool.exe`).
 - **Version:** Default `0.0.0`, CI sets `-p:Version=$buildNum.0.0`. Tags use `vN` format. Auto-updater compares `Version.Major` as integer.
 - **Code signing:** Self-signed cert, auto-generated on first run, stored as `SIGNING_CERTIFICATE`/`SIGNING_CERTIFICATE_PASSWORD` secrets. Requires `GH_PAT` for persistence. 5-year validity, auto-renews at 30 days remaining.
 - **Publishing:** `dotnet publish PaperNexus/PaperNexus.csproj -c Release -r win-x64 --self-contained true -p:PublishSingleFile=true -p:IncludeNativeLibrariesForSelfExtract=true -p:PublishTrimmed=false`
+- **Self-hosted runner:** Both workflows run on `[self-hosted, Linux, X64]`. The runner has no system .NET SDK and its user cannot write `/usr/share/dotnet`, so every job needs `actions/setup-dotnet@v5` with `DOTNET_INSTALL_DIR: ${{ runner.tool_cache }}/dotnet`. Tools that persist between runs (osslsigncode) are reused rather than reinstalled.
 - **Actions maintenance:** 30-day cycle. **Next update: March 28, 2026.**
 
 ## Guidelines

--- a/PaperNexus.Tests/PaperNexus.Tests.csproj
+++ b/PaperNexus.Tests/PaperNexus.Tests.csproj
@@ -5,7 +5,6 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>
-    <PlatformTarget>x64</PlatformTarget>
   </PropertyGroup>
 
   <ItemGroup>

--- a/PaperNexus.Tests/PlatformTests.cs
+++ b/PaperNexus.Tests/PlatformTests.cs
@@ -1,0 +1,91 @@
+using PaperNexus.Core.Platform;
+using Xunit;
+
+namespace PaperNexus.Tests;
+
+// Covers the cross-platform conventions that replaced the app's Windows-only assumptions.
+// Nothing here touches the registry, the desktop shell, or a real wallpaper.
+public class PlatformPathsTests
+{
+    [Fact]
+    public void ExecutableName_MatchesTheHostPlatformConvention()
+    {
+        var expected = OperatingSystem.IsWindows() ? "PaperNexus.exe" : "PaperNexus";
+        Assert.Equal(expected, PlatformPaths.ExecutableName);
+    }
+
+    [Fact]
+    public void PathEquals_IsCaseSensitiveOnlyWhereTheFileSystemIs()
+    {
+        // Windows paths are case-insensitive; Linux paths are not. Treating "/a/Pic.png"
+        // and "/a/pic.png" as the same file on Linux would collide distinct wallpapers.
+        var matches = PlatformPaths.PathEquals("/tmp/Pic.png", "/tmp/pic.png");
+        Assert.Equal(OperatingSystem.IsWindows(), matches);
+    }
+
+    [Fact]
+    public void PathEquals_MatchesIdenticalPaths()
+    {
+        Assert.True(PlatformPaths.PathEquals("/tmp/pic.png", "/tmp/pic.png"));
+    }
+
+    [Fact]
+    public void PathEquals_TreatsNullsAsUnequalToAnyPath()
+    {
+        Assert.False(PlatformPaths.PathEquals(null, "/tmp/pic.png"));
+        Assert.False(PlatformPaths.PathEquals("/tmp/pic.png", null));
+        Assert.True(PlatformPaths.PathEquals(null, null));
+    }
+
+    [Fact]
+    public void DefaultInstallDirectory_IsAnAbsoluteUserWritablePath()
+    {
+        // A relative path here would place the install (and settings.json) wherever the
+        // process happened to be launched from - the failure mode when Linux has no
+        // XDG user-dirs configured.
+        var installDir = PlatformPaths.DefaultInstallDirectory;
+        Assert.True(Path.IsPathRooted(installDir));
+        Assert.EndsWith("PaperNexus", installDir);
+    }
+
+    [Fact]
+    public void DefaultPicturesDirectory_IsAnAbsolutePath()
+    {
+        Assert.True(Path.IsPathRooted(PlatformPaths.DefaultPicturesDirectory));
+    }
+}
+
+public class LinuxDesktopTests
+{
+    [Theory]
+    [InlineData("KDE")]
+    [InlineData("plasma")]
+    [InlineData("KDE:plasmawayland")]
+    public void Classify_RecognisesPlasmaSessions(string sessionName)
+    {
+        Assert.Equal(LinuxDesktopEnvironment.Kde, LinuxDesktop.Classify([sessionName]));
+    }
+
+    [Theory]
+    [InlineData("GNOME")]
+    [InlineData("ubuntu:GNOME")]
+    [InlineData("X-Cinnamon")]
+    public void Classify_RecognisesGnomeDerivedSessions(string sessionName)
+    {
+        Assert.Equal(LinuxDesktopEnvironment.Gnome, LinuxDesktop.Classify([sessionName]));
+    }
+
+    [Fact]
+    public void Classify_FallsThroughEmptyValuesToTheNextCandidate()
+    {
+        // XDG_CURRENT_DESKTOP is often unset while DESKTOP_SESSION is populated.
+        Assert.Equal(LinuxDesktopEnvironment.Kde, LinuxDesktop.Classify([null, "", "plasma"]));
+    }
+
+    [Fact]
+    public void Classify_ReturnsUnknownForUnrecognisedSessions()
+    {
+        Assert.Equal(LinuxDesktopEnvironment.Unknown, LinuxDesktop.Classify(["sway", "i3"]));
+        Assert.Equal(LinuxDesktopEnvironment.Unknown, LinuxDesktop.Classify([]));
+    }
+}

--- a/PaperNexus/App.axaml.cs
+++ b/PaperNexus/App.axaml.cs
@@ -7,7 +7,6 @@ using Avalonia.Platform;
 using Avalonia.Threading;
 using PaperNexus.Views;
 using PaperNexus.ViewModels;
-using Microsoft.Win32;
 using SixLabors.ImageSharp;
 using SixLabors.ImageSharp.Drawing;
 using SixLabors.ImageSharp.Drawing.Processing;
@@ -46,7 +45,7 @@ public partial class App : Application
             // Keep running when any window is closed
             desktop.ShutdownMode = ShutdownMode.OnExplicitShutdown;
 
-            // In install mode, show only the install screen — skip all service/tray setup.
+            // In install mode, show only the install screen - skip all service/tray setup.
             if (Program.IsInstallMode)
             {
                 new Views.InstallScreen().Show();
@@ -67,13 +66,11 @@ public partial class App : Application
                 .Build();
 
             // Apply startup registration based on the persisted setting
-#pragma warning disable CA1416
             _ = WallpaperNexusSettings.LoadAsync().ContinueWith(t =>
             {
-                try { UpdateStartupRegistration(t.Result.RunOnStartup); }
+                try { StartupRegistration.Update(t.Result.RunOnStartup); }
                 catch (Exception ex) { Logger?.LogError(ex, "Failed to apply startup registration on launch."); }
             });
-#pragma warning restore CA1416
 
             var launchedOnStartup = desktop.Args?.Contains("--startup") == true;
 
@@ -85,7 +82,7 @@ public partial class App : Application
             }
 
             // Close the splash once the background host has started, but show it for at least 2 seconds.
-            // In debug mode skip the delay and go straight to the main window — avoids a window-count-zero
+            // In debug mode skip the delay and go straight to the main window - avoids a window-count-zero
             // gap that would trigger OnLastWindowClose shutdown before the main window opens.
             var splashDelay = Program.IsDebugMode ? Task.CompletedTask : Task.Delay(2000);
             _ = Task.WhenAll(_backgroundHost.StartAsync(), splashDelay).ContinueWith(_ =>
@@ -97,32 +94,18 @@ public partial class App : Application
                         ShowMainWindow();
                 }));
 
-            // Show only the tray icon — no window at startup
+            // Show only the tray icon - no window at startup
             SetupTrayIcon(desktop);
 
-            // Monitor for show-UI signals from second instances
-            if (Program.ShowUIEvent is not null)
+            // Monitor for show-UI signals from second instances. The listener blocks while
+            // waiting, so it runs on its own thread and polls internally for _exiting.
+            // Window creation must happen on the UI thread, hence the dispatcher post.
+            var singleInstance = Program.Instance;
+            if (singleInstance is not null)
             {
-                _ = Task.Run(() =>
-                {
-                    // Poll with a 1-second timeout so we can check _exiting without blocking forever
-                    while (!_exiting)
-                    {
-                        try
-                        {
-                            if (Program.ShowUIEvent.WaitOne(1000))
-                            {
-                                if (!_exiting)
-                                    ShowMainWindow();
-                            }
-                        }
-                        catch (ObjectDisposedException)
-                        {
-                            // Event was disposed during shutdown — exit the listener loop
-                            break;
-                        }
-                    }
-                });
+                _ = Task.Run(() => singleInstance.Listen(
+                    onShowRequested: () => Dispatcher.UIThread.Post(ShowMainWindow),
+                    stopWhen: () => _exiting));
             }
         }
 
@@ -183,7 +166,7 @@ public partial class App : Application
                 if (switcher is null)
                     return;
                 var next = await Task.Run(switcher.SwitchToRandomAsync);
-                // Same fallback pattern as "Next Wallpaper" — download if the folder is empty
+                // Same fallback pattern as "Next Wallpaper" - download if the folder is empty
                 if (next is null)
                 {
                     var downloader = _backgroundHost?.Services.GetService<IDownloadWallpapers>();
@@ -349,26 +332,4 @@ public partial class App : Application
         ctx.Fill(Color.Tomato, new RectangularPolygon(7, 2, 2, 7));
     });
 
-    // Adds or removes the Windows startup registry entry under HKCU\...\Run.
-    // Also removes legacy key names from earlier app versions to clean up on upgrade.
-    [System.Runtime.Versioning.SupportedOSPlatform("windows")]
-    internal static void UpdateStartupRegistration(bool enable)
-    {
-        using var key = Registry.CurrentUser.OpenSubKey(
-            @"SOFTWARE\Microsoft\Windows\CurrentVersion\Run", writable: true);
-        // Clean up old names from previous app identity
-        key?.DeleteValue("Excogitated Wallpaper Service", throwOnMissingValue: false);
-        key?.DeleteValue("Wallpaper Nexus", throwOnMissingValue: false);
-        if (enable)
-        {
-            var exePath = Environment.ProcessPath
-                ?? Path.ChangeExtension(Assembly.GetEntryAssembly()!.Location, ".exe");
-            // Pass --startup so the app knows it was launched by Windows at login
-            key?.SetValue("PaperNexus", $"\"{exePath}\" --startup");
-        }
-        else
-        {
-            key?.DeleteValue("PaperNexus", throwOnMissingValue: false);
-        }
-    }
 }

--- a/PaperNexus/AutoUpdateService.cs
+++ b/PaperNexus/AutoUpdateService.cs
@@ -14,13 +14,21 @@ internal interface ICheckForUpdates
 internal sealed class AutoUpdateService : ICheckForUpdates, IAddSingleton<ICheckForUpdates>
 {
     private const string GitHubRepo = "0Keith/PaperNexus";
-    private const string AssetName = "PaperNexus.exe";
+
+    // Each platform ships its own release asset. The Windows build is Authenticode-signed,
+    // which is a PE-only format, so the Linux build's integrity is verified against a
+    // SHA-256 digest published alongside it instead.
+    private static string AssetName => OperatingSystem.IsWindows()
+        ? "PaperNexus.exe"
+        : "PaperNexus-linux-x64";
+
+    private static string ChecksumAssetName => AssetName + ".sha256";
 
     private readonly ILogger<AutoUpdateService> _logger;
 
     // Two separate HttpClient instances, both long-lived singletons on this service:
-    //   _apiClient  — short 30-second timeout for small GitHub API JSON responses.
-    //   _downloadClient — 10-minute timeout for streaming the full exe binary (50+ MB).
+    //   _apiClient  - short 30-second timeout for small GitHub API JSON responses.
+    //   _downloadClient - 10-minute timeout for streaming the full exe binary (50+ MB).
     // Using a single 30-second client caused reliable timeouts on slow connections during
     // the body-streaming phase even though headers arrived quickly, because HttpClient's
     // Timeout counts from the moment the request is initiated, not just the header wait.
@@ -82,7 +90,7 @@ internal sealed class AutoUpdateService : ICheckForUpdates, IAddSingleton<ICheck
             throw new InvalidOperationException("Release version tag is empty.");
         }
 
-        // Tags are "vN" — strip the leading 'v' and parse as an integer build number
+        // Tags are "vN" - strip the leading 'v' and parse as an integer build number
         var versionStr = tag.TrimStart('v');
         if (!int.TryParse(versionStr, out var latestBuild))
         {
@@ -107,16 +115,21 @@ internal sealed class AutoUpdateService : ICheckForUpdates, IAddSingleton<ICheck
             throw new InvalidOperationException($"No assets found in release {tag}.");
         }
 
-        // Find the download URL for PaperNexus.exe in the release assets list
+        // Find the download URL for this platform's binary, plus its checksum sidecar
+        // if the release publishes one (used for integrity verification on Linux).
         string? downloadUrl = null;
+        string? checksumUrl = null;
         foreach (var asset in assetsElement.EnumerateArray())
         {
-            if (asset.TryGetProperty("name", out var nameEl) && nameEl.GetString() == AssetName
-                && asset.TryGetProperty("browser_download_url", out var urlEl))
-            {
+            if (!asset.TryGetProperty("name", out var nameEl)
+                || !asset.TryGetProperty("browser_download_url", out var urlEl))
+                continue;
+
+            var assetName = nameEl.GetString();
+            if (assetName == AssetName)
                 downloadUrl = urlEl.GetString();
-                break;
-            }
+            else if (assetName == ChecksumAssetName)
+                checksumUrl = urlEl.GetString();
         }
 
         if (downloadUrl is null)
@@ -130,8 +143,9 @@ internal sealed class AutoUpdateService : ICheckForUpdates, IAddSingleton<ICheck
         // Stage the download beside the running exe; the batch script will move it into place
         var newExePath = exePath + ".new";
         var backupPath = exePath + ".bak";
-        // Use a unique batch name to avoid collisions if a previous update was interrupted
-        var batchPath = Path.Combine(Path.GetDirectoryName(exePath)!, $"update-{Guid.NewGuid():N}.bat");
+        // Use a unique script name to avoid collisions if a previous update was interrupted
+        var scriptExtension = OperatingSystem.IsWindows() ? "bat" : "sh";
+        var scriptPath = Path.Combine(Path.GetDirectoryName(exePath)!, $"update-{Guid.NewGuid():N}.{scriptExtension}");
 
         _logger.LogInformation("Downloading v{Latest} from {Url}", latestBuild, downloadUrl);
         progress?.Report($"Downloading {tag}...");
@@ -156,70 +170,57 @@ internal sealed class AutoUpdateService : ICheckForUpdates, IAddSingleton<ICheck
             throw;
         }
 
-        // Verify the downloaded exe has a valid Authenticode signature from PaperNexus.
-        // This prevents executing a tampered or unsigned binary.
-        if (!VerifyAuthenticodeSignature(newExePath))
+        // Verify the download before it is ever executed, so a tampered or truncated
+        // binary is discarded rather than swapped into place.
+        if (!await VerifyDownloadAsync(newExePath, checksumUrl))
         {
             File.Delete(newExePath);
-            _logger.LogWarning("Update signature verification failed. Update aborted.");
-            throw new InvalidOperationException("Downloaded update failed signature verification.");
+            _logger.LogWarning("Update integrity verification failed. Update aborted.");
+            throw new InvalidOperationException("Downloaded update failed integrity verification.");
         }
 
-        // Remove the Zone.Identifier alternate data stream so Smart App Control
-        // does not treat the downloaded file as untrusted internet content.
-        try
+        if (OperatingSystem.IsWindows())
         {
-            File.Delete(newExePath + ":Zone.Identifier");
+            // Remove the Zone.Identifier alternate data stream so Smart App Control
+            // does not treat the downloaded file as untrusted internet content.
+            try
+            {
+                File.Delete(newExePath + ":Zone.Identifier");
+            }
+            catch (Exception ex)
+            {
+                _logger.LogDebug("Zone.Identifier removal skipped: {Message}", ex.Message);
+            }
         }
-        catch (Exception ex)
+        else
         {
-            _logger.LogDebug("Zone.Identifier removal skipped: {Message}", ex.Message);
+            // The download arrives without the execute bit, which the swap script needs.
+            PlatformPaths.EnsureExecutable(newExePath);
         }
 
-        // The batch script:
+        // The swap script (same steps on both platforms, written in each one's shell):
         //  1. Waits 2 s for the current process to exit
-        //  2. Backs up the running exe
-        //  3. Moves the new exe into place
+        //  2. Backs up the running binary
+        //  3. Moves the new binary into place
         //  4. Launches the updated app
         //  5. Waits 8 s and checks the process is running; if not, rolls back from backup
         //  6. Deletes the backup and self-deletes
         try
         {
-            await File.WriteAllTextAsync(batchPath,
-                $"""
-                @echo off
-                timeout /t 2 /nobreak > nul
-                copy /y "{exePath}" "{backupPath}" > nul
-                if errorlevel 1 exit /b 1
-                move /y "{newExePath}" "{exePath}"
-                if errorlevel 1 (
-                    del "{backupPath}" 2>nul
-                    exit /b 1
-                )
-                start "" "{exePath}" --updated
-                timeout /t 8 /nobreak > nul
-                tasklist /fi "imagename eq {AssetName}" /fo csv 2>nul | findstr /i "{Path.GetFileNameWithoutExtension(AssetName)}" > nul
-                if errorlevel 1 (
-                    copy /y "{backupPath}" "{exePath}" > nul
-                    start "" "{exePath}"
-                )
-                del "{backupPath}" 2>nul
-                del "%~f0"
-                """);
+            if (OperatingSystem.IsWindows())
+                await WriteWindowsSwapScriptAsync(scriptPath, exePath, newExePath, backupPath);
+            else
+                await WriteUnixSwapScriptAsync(scriptPath, exePath, newExePath, backupPath);
 
-            Process.Start(new ProcessStartInfo("cmd.exe", $"/c \"{batchPath}\"")
-            {
-                CreateNoWindow = true,
-                UseShellExecute = false,
-            });
+            LaunchSwapScript(scriptPath);
         }
         catch (Exception ex)
         {
-            // Clean up the staged binary and batch script so the install directory is not
+            // Clean up the staged binary and script so the install directory is not
             // left with orphaned files. The update will be retried at the next scheduled check.
             _logger.LogWarning("Failed to launch updater script: {Message}", ex.Message);
             try { File.Delete(newExePath); } catch { }
-            try { File.Delete(batchPath); } catch { }
+            try { File.Delete(scriptPath); } catch { }
             throw;
         }
 
@@ -229,9 +230,117 @@ internal sealed class AutoUpdateService : ICheckForUpdates, IAddSingleton<ICheck
         Environment.Exit(0);
     }
 
+    private static Task WriteWindowsSwapScriptAsync(string scriptPath, string exePath, string newExePath, string backupPath)
+    {
+        var processName = Path.GetFileName(exePath);
+        return File.WriteAllTextAsync(scriptPath,
+            $"""
+            @echo off
+            timeout /t 2 /nobreak > nul
+            copy /y "{exePath}" "{backupPath}" > nul
+            if errorlevel 1 exit /b 1
+            move /y "{newExePath}" "{exePath}"
+            if errorlevel 1 (
+                del "{backupPath}" 2>nul
+                exit /b 1
+            )
+            start "" "{exePath}" --updated
+            timeout /t 8 /nobreak > nul
+            tasklist /fi "imagename eq {processName}" /fo csv 2>nul | findstr /i "{Path.GetFileNameWithoutExtension(processName)}" > nul
+            if errorlevel 1 (
+                copy /y "{backupPath}" "{exePath}" > nul
+                start "" "{exePath}"
+            )
+            del "{backupPath}" 2>nul
+            del "%~f0"
+            """);
+    }
+
+    private static async Task WriteUnixSwapScriptAsync(string scriptPath, string exePath, string newExePath, string backupPath)
+    {
+        // setsid detaches the relaunched app from this script's process group so it
+        // survives the script exiting. pgrep -f matches the full command line because the
+        // Linux binary has no extension for pgrep's default name match to key on.
+        var script = $"""
+            #!/bin/sh
+            sleep 2
+            cp -f '{exePath}' '{backupPath}' || exit 1
+            if ! mv -f '{newExePath}' '{exePath}'; then
+                rm -f '{backupPath}'
+                exit 1
+            fi
+            chmod +x '{exePath}'
+            setsid '{exePath}' --updated >/dev/null 2>&1 &
+            sleep 8
+            if ! pgrep -f '{exePath}' >/dev/null 2>&1; then
+                cp -f '{backupPath}' '{exePath}'
+                chmod +x '{exePath}'
+                setsid '{exePath}' >/dev/null 2>&1 &
+            fi
+            rm -f '{backupPath}'
+            rm -f "$0"
+            """;
+
+        await File.WriteAllTextAsync(scriptPath, script.ReplaceLineEndings("\n"));
+        PlatformPaths.EnsureExecutable(scriptPath);
+    }
+
+    private static void LaunchSwapScript(string scriptPath)
+    {
+        var startInfo = OperatingSystem.IsWindows()
+            ? new ProcessStartInfo("cmd.exe", $"/c \"{scriptPath}\"")
+            : new ProcessStartInfo("/bin/sh", scriptPath);
+        startInfo.CreateNoWindow = true;
+        startInfo.UseShellExecute = false;
+        Process.Start(startInfo);
+    }
+
+    // Confirms the staged download is the artifact the release published, before it is
+    // executed. Windows builds carry an Authenticode signature; Linux builds are matched
+    // against the SHA-256 digest published as a sidecar asset in the same release.
+    private async Task<bool> VerifyDownloadAsync(string filePath, string? checksumUrl)
+    {
+        if (OperatingSystem.IsWindows())
+            return VerifyAuthenticodeSignature(filePath);
+
+        if (string.IsNullOrEmpty(checksumUrl))
+        {
+            _logger.LogWarning("Release publishes no '{Asset}' checksum; refusing to install an unverifiable update.", ChecksumAssetName);
+            return false;
+        }
+
+        string expected;
+        try
+        {
+            // The sidecar is in `sha256sum` format: "<hex digest>  <filename>".
+            var contents = await _apiClient.GetStringAsync(checksumUrl);
+            expected = contents.Trim().Split((char[]?)null, StringSplitOptions.RemoveEmptyEntries)[0];
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning("Could not fetch update checksum: {Message}", ex.Message);
+            return false;
+        }
+
+        string actual;
+        await using (var stream = File.OpenRead(filePath))
+        {
+            var digest = await System.Security.Cryptography.SHA256.HashDataAsync(stream);
+            actual = Convert.ToHexString(digest);
+        }
+
+        if (!string.Equals(actual, expected, StringComparison.OrdinalIgnoreCase))
+        {
+            _logger.LogWarning("Update checksum mismatch. Expected {Expected}, got {Actual}.", expected, actual);
+            return false;
+        }
+        return true;
+    }
+
     // Checks that the file at filePath carries a valid Authenticode signature whose
     // subject CN matches "PaperNexus". Returns false (rather than throwing) if the
     // certificate is missing, invalid, or signed by an unexpected issuer.
+    [System.Runtime.Versioning.SupportedOSPlatform("windows")]
     private bool VerifyAuthenticodeSignature(string filePath)
     {
         try

--- a/PaperNexus/Core/Platform/IWallpaperBackend.cs
+++ b/PaperNexus/Core/Platform/IWallpaperBackend.cs
@@ -1,0 +1,18 @@
+namespace PaperNexus.Core.Platform;
+
+// Per-OS implementation of the two operations the app needs from the desktop shell.
+// WallpaperApplier selects the right backend once at construction.
+public interface IWallpaperBackend
+{
+    public bool SetWallpaper(string wallpaperPath);
+    public void ApplyFillStyle(WallpaperFillStyle style);
+}
+
+// Used when the running platform/desktop has no supported wallpaper mechanism, so the
+// rest of the app (downloads, gallery, scheduling) still functions instead of crashing.
+public sealed class NoOpWallpaperBackend : IWallpaperBackend
+{
+    public bool SetWallpaper(string wallpaperPath) => false;
+
+    public void ApplyFillStyle(WallpaperFillStyle style) { }
+}

--- a/PaperNexus/Core/Platform/LinuxDesktop.cs
+++ b/PaperNexus/Core/Platform/LinuxDesktop.cs
@@ -1,0 +1,141 @@
+using System.Diagnostics;
+
+namespace PaperNexus.Core.Platform;
+
+// The Linux desktop environments PaperNexus knows how to drive. Anything unrecognised
+// falls back to a generic X11/Wayland setter tool if one is installed.
+public enum LinuxDesktopEnvironment
+{
+    Unknown,
+    Kde,
+    Gnome,
+}
+
+// Detects the running desktop environment and runs short-lived helper commands.
+// Kept separate from the wallpaper logic so tests can exercise the command-building
+// without spawning real processes.
+public static class LinuxDesktop
+{
+    // Reads the freedesktop-standard environment variables the session manager sets.
+    // XDG_CURRENT_DESKTOP is colon-separated (e.g. "ubuntu:GNOME"), so match on substrings.
+    public static LinuxDesktopEnvironment Detect()
+    {
+        var candidates = new[]
+        {
+            Environment.GetEnvironmentVariable("XDG_CURRENT_DESKTOP"),
+            Environment.GetEnvironmentVariable("XDG_SESSION_DESKTOP"),
+            Environment.GetEnvironmentVariable("DESKTOP_SESSION"),
+        };
+
+        var fromEnvironment = Classify(candidates);
+        if (fromEnvironment != LinuxDesktopEnvironment.Unknown)
+            return fromEnvironment;
+
+        // No desktop hint in the environment - infer from what is actually running.
+        if (IsProcessRunning("plasmashell"))
+            return LinuxDesktopEnvironment.Kde;
+        if (IsProcessRunning("gnome-shell"))
+            return LinuxDesktopEnvironment.Gnome;
+
+        return LinuxDesktopEnvironment.Unknown;
+    }
+
+    // Maps freedesktop session identifiers onto the desktops this app can drive.
+    // Separated from Detect so it can be exercised without a live session.
+    internal static LinuxDesktopEnvironment Classify(IEnumerable<string?> candidates)
+    {
+        foreach (var candidate in candidates)
+        {
+            if (string.IsNullOrEmpty(candidate))
+                continue;
+            if (candidate.Contains("kde", StringComparison.OrdinalIgnoreCase)
+                || candidate.Contains("plasma", StringComparison.OrdinalIgnoreCase))
+                return LinuxDesktopEnvironment.Kde;
+            if (candidate.Contains("gnome", StringComparison.OrdinalIgnoreCase)
+                || candidate.Contains("unity", StringComparison.OrdinalIgnoreCase)
+                || candidate.Contains("cinnamon", StringComparison.OrdinalIgnoreCase))
+                return LinuxDesktopEnvironment.Gnome;
+        }
+
+        return LinuxDesktopEnvironment.Unknown;
+    }
+
+    private static bool IsProcessRunning(string processName)
+    {
+        try
+        {
+            return Process.GetProcessesByName(processName).Length > 0;
+        }
+        catch
+        {
+            return false;
+        }
+    }
+
+    // True when the named executable resolves on PATH. Used to pick between the
+    // several tools that can set a wallpaper on an unrecognised desktop.
+    public static bool CommandExists(string command)
+    {
+        var pathVariable = Environment.GetEnvironmentVariable("PATH");
+        if (string.IsNullOrEmpty(pathVariable))
+            return false;
+
+        foreach (var directory in pathVariable.Split(Path.PathSeparator, StringSplitOptions.RemoveEmptyEntries))
+        {
+            var fullPath = Path.Combine(directory, command);
+            if (File.Exists(fullPath))
+                return true;
+        }
+        return false;
+    }
+
+    // Starts a long-lived helper (such as swaybg) without waiting for it to exit, and
+    // returns the process so the caller can replace it on the next wallpaper switch.
+    public static Process? StartDetached(string fileName, params string[] arguments)
+    {
+        try
+        {
+            var startInfo = new ProcessStartInfo(fileName) { UseShellExecute = false };
+            foreach (var argument in arguments)
+                startInfo.ArgumentList.Add(argument);
+            return Process.Start(startInfo);
+        }
+        catch
+        {
+            return null;
+        }
+    }
+
+    // Runs a command to completion and reports whether it exited cleanly.
+    // Output is captured (not inherited) so helper chatter never reaches the app's console.
+    public static bool Run(string fileName, params string[] arguments)
+    {
+        try
+        {
+            var startInfo = new ProcessStartInfo(fileName)
+            {
+                UseShellExecute = false,
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+            };
+            foreach (var argument in arguments)
+                startInfo.ArgumentList.Add(argument);
+
+            using var process = Process.Start(startInfo);
+            if (process is null)
+                return false;
+
+            // Bound the wait so a hung helper cannot stall the wallpaper switch.
+            if (!process.WaitForExit(15_000))
+            {
+                try { process.Kill(entireProcessTree: true); } catch { /* already gone */ }
+                return false;
+            }
+            return process.ExitCode == 0;
+        }
+        catch
+        {
+            return false;
+        }
+    }
+}

--- a/PaperNexus/Core/Platform/LinuxWallpaperBackend.cs
+++ b/PaperNexus/Core/Platform/LinuxWallpaperBackend.cs
@@ -1,0 +1,185 @@
+namespace PaperNexus.Core.Platform;
+
+// Sets the desktop wallpaper on Linux. There is no cross-desktop API for this, so the
+// backend dispatches to the mechanism the running desktop environment provides:
+//   KDE Plasma (the SteamOS Desktop Mode shell) - a JavaScript snippet run through
+//                                                 plasmashell's D-Bus evaluateScript
+//   GNOME                                       - gsettings keys under org.gnome.desktop.background
+//   anything else                               - feh / xwallpaper / swaybg if installed
+public sealed class LinuxWallpaperBackend : IWallpaperBackend
+{
+    private readonly LinuxDesktopEnvironment _desktop = LinuxDesktop.Detect();
+
+    // The fill style is applied by the same command that sets the image on KDE, so it is
+    // cached here and replayed whenever either half changes.
+    private WallpaperFillStyle _fillStyle = WallpaperFillStyle.Fill;
+    private string? _currentPath;
+
+    public bool SetWallpaper(string wallpaperPath)
+    {
+        if (!File.Exists(wallpaperPath))
+            return false;
+
+        _currentPath = wallpaperPath;
+        return Apply(wallpaperPath, _fillStyle);
+    }
+
+    public void ApplyFillStyle(WallpaperFillStyle style)
+    {
+        _fillStyle = style;
+        // Re-apply against the image already on screen so the new style takes effect
+        // immediately rather than at the next scheduled switch.
+        if (_currentPath is not null)
+            Apply(_currentPath, style);
+    }
+
+    private bool Apply(string wallpaperPath, WallpaperFillStyle style) => _desktop switch
+    {
+        LinuxDesktopEnvironment.Kde => ApplyKde(wallpaperPath, style),
+        LinuxDesktopEnvironment.Gnome => ApplyGnome(wallpaperPath, style),
+        _ => ApplyGeneric(wallpaperPath, style),
+    };
+
+    // KDE Plasma stores the wallpaper in each containment's config. Plasma only repaints
+    // when the stored value actually changes, and PaperNexus always writes to the same
+    // current.png, so the script clears the Image key before writing the real path.
+    private static bool ApplyKde(string wallpaperPath, WallpaperFillStyle style)
+    {
+        var fillMode = style switch
+        {
+            WallpaperFillStyle.Stretch => 0,
+            WallpaperFillStyle.Fit => 1,
+            WallpaperFillStyle.Fill => 2,
+            WallpaperFillStyle.Span => 2,
+            WallpaperFillStyle.Tile => 3,
+            WallpaperFillStyle.Center => 6,
+            _ => 2,
+        };
+
+        var imageUri = new Uri(wallpaperPath).AbsoluteUri;
+        var script = $$"""
+            var screens = desktops();
+            for (var i = 0; i < screens.length; i++) {
+                var desktop = screens[i];
+                desktop.wallpaperPlugin = "org.kde.image";
+                desktop.currentConfigGroup = Array("Wallpaper", "org.kde.image", "General");
+                desktop.writeConfig("FillMode", {{fillMode}});
+                desktop.writeConfig("Image", "");
+                desktop.writeConfig("Image", "{{imageUri}}");
+            }
+            """;
+
+        // The qdbus binary is named differently across Qt versions and distributions.
+        foreach (var qdbus in new[] { "qdbus6", "qdbus-qt6", "qdbus", "qdbus-qt5" })
+        {
+            if (!LinuxDesktop.CommandExists(qdbus))
+                continue;
+            if (LinuxDesktop.Run(qdbus, "org.kde.plasmashell", "/PlasmaShell", "org.kde.PlasmaShell.evaluateScript", script))
+                return true;
+        }
+
+        // Fall back to the shipped CLI tool, which sets the image but not the fill mode.
+        if (LinuxDesktop.CommandExists("plasma-apply-wallpaperimage"))
+            return LinuxDesktop.Run("plasma-apply-wallpaperimage", wallpaperPath);
+
+        return false;
+    }
+
+    // GNOME reads the wallpaper from GSettings. Both the light and dark keys must be set,
+    // otherwise the wallpaper appears to not change under the dark colour scheme.
+    private static bool ApplyGnome(string wallpaperPath, WallpaperFillStyle style)
+    {
+        if (!LinuxDesktop.CommandExists("gsettings"))
+            return false;
+
+        var pictureOption = style switch
+        {
+            WallpaperFillStyle.Tile => "wallpaper",
+            WallpaperFillStyle.Center => "centered",
+            WallpaperFillStyle.Stretch => "stretched",
+            WallpaperFillStyle.Fit => "scaled",
+            WallpaperFillStyle.Fill => "zoom",
+            WallpaperFillStyle.Span => "spanned",
+            _ => "zoom",
+        };
+
+        var imageUri = new Uri(wallpaperPath).AbsoluteUri;
+        const string schema = "org.gnome.desktop.background";
+
+        LinuxDesktop.Run("gsettings", "set", schema, "picture-options", pictureOption);
+
+        // Clearing first forces a repaint when the path is unchanged from the previous switch.
+        var applied = false;
+        foreach (var key in new[] { "picture-uri", "picture-uri-dark" })
+        {
+            LinuxDesktop.Run("gsettings", "set", schema, key, "");
+            applied |= LinuxDesktop.Run("gsettings", "set", schema, key, imageUri);
+        }
+        return applied;
+    }
+
+    // swaybg runs for as long as the wallpaper is displayed, so the previous instance is
+    // kept here and terminated before a replacement is started.
+    private System.Diagnostics.Process? _swaybg;
+
+    // Standalone setters used by minimal window managers. Each is tried in turn.
+    private bool ApplyGeneric(string wallpaperPath, WallpaperFillStyle style)
+    {
+        if (LinuxDesktop.CommandExists("feh"))
+        {
+            var mode = style switch
+            {
+                WallpaperFillStyle.Tile => "--bg-tile",
+                WallpaperFillStyle.Center => "--bg-center",
+                WallpaperFillStyle.Stretch => "--bg-scale",
+                WallpaperFillStyle.Fit => "--bg-max",
+                _ => "--bg-fill",
+            };
+            if (LinuxDesktop.Run("feh", "--no-fehbg", mode, wallpaperPath))
+                return true;
+        }
+
+        if (LinuxDesktop.CommandExists("xwallpaper"))
+        {
+            var mode = style switch
+            {
+                WallpaperFillStyle.Tile => "--tile",
+                WallpaperFillStyle.Center => "--center",
+                WallpaperFillStyle.Stretch => "--stretch",
+                WallpaperFillStyle.Fit => "--maximize",
+                _ => "--zoom",
+            };
+            if (LinuxDesktop.Run("xwallpaper", mode, wallpaperPath))
+                return true;
+        }
+
+        if (LinuxDesktop.CommandExists("swaybg"))
+        {
+            var mode = style switch
+            {
+                WallpaperFillStyle.Tile => "tile",
+                WallpaperFillStyle.Center => "center",
+                WallpaperFillStyle.Stretch => "stretch",
+                WallpaperFillStyle.Fit => "fit",
+                _ => "fill",
+            };
+
+            var replacement = LinuxDesktop.StartDetached("swaybg", "-i", wallpaperPath, "-m", mode);
+            if (replacement is null)
+                return false;
+
+            // Kill the old instance only after the replacement is up, to avoid a visible
+            // gap where no wallpaper is drawn at all.
+            var previous = _swaybg;
+            _swaybg = replacement;
+            if (previous is not null)
+            {
+                try { previous.Kill(entireProcessTree: true); } catch { /* already exited */ }
+                previous.Dispose();
+            }
+            return true;
+        }
+
+        return false;
+    }
+}

--- a/PaperNexus/Core/Platform/PlatformPaths.cs
+++ b/PaperNexus/Core/Platform/PlatformPaths.cs
@@ -1,0 +1,67 @@
+namespace PaperNexus.Core.Platform;
+
+// Centralises the file-system conventions that differ between Windows and Linux so the
+// rest of the app never hardcodes ".exe" or assumes case-insensitive path comparison.
+public static class PlatformPaths
+{
+    // Windows produces "PaperNexus.exe"; Linux produces an extensionless "PaperNexus" apphost.
+    public static string ExecutableName => OperatingSystem.IsWindows() ? "PaperNexus.exe" : "PaperNexus";
+
+    // Linux file systems are case-sensitive, so comparing paths case-insensitively there
+    // would wrongly treat "/home/a/Pic.png" and "/home/a/pic.png" as the same file.
+    public static StringComparison PathComparison => OperatingSystem.IsWindows()
+        ? StringComparison.OrdinalIgnoreCase
+        : StringComparison.Ordinal;
+
+    public static bool PathEquals(string? left, string? right)
+    {
+        if (left is null || right is null)
+            return ReferenceEquals(left, right);
+        return string.Equals(left, right, PathComparison);
+    }
+
+    // Default install directory. LocalApplicationData maps to %LOCALAPPDATA% on Windows and
+    // ~/.local/share on Linux - both are user-writable, which matters on immutable
+    // distributions such as SteamOS where the system root is read-only.
+    public static string DefaultInstallDirectory
+    {
+        get
+        {
+            var localAppData = Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData);
+            if (string.IsNullOrEmpty(localAppData))
+                localAppData = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), ".local", "share");
+            return Path.Combine(localAppData, "PaperNexus");
+        }
+    }
+
+    // Environment.GetFolderPath(MyPictures) returns an empty string on Linux when the
+    // XDG user-dirs config is missing, which would otherwise yield a relative path.
+    public static string DefaultPicturesDirectory
+    {
+        get
+        {
+            var pictures = Environment.GetFolderPath(Environment.SpecialFolder.MyPictures);
+            if (string.IsNullOrEmpty(pictures))
+                pictures = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), "Pictures");
+            return pictures;
+        }
+    }
+
+    // Marks a freshly copied file as executable. No-op on Windows, which has no execute bit.
+    public static void EnsureExecutable(string path)
+    {
+        if (OperatingSystem.IsWindows())
+            return;
+
+        try
+        {
+            var mode = File.GetUnixFileMode(path);
+            File.SetUnixFileMode(path, mode
+                | UnixFileMode.UserExecute
+                | UnixFileMode.GroupExecute
+                | UnixFileMode.OtherExecute);
+        }
+        catch (IOException) { /* best-effort - the copy may already carry the execute bit */ }
+        catch (UnauthorizedAccessException) { /* best-effort */ }
+    }
+}

--- a/PaperNexus/Core/Platform/ShellOpener.cs
+++ b/PaperNexus/Core/Platform/ShellOpener.cs
@@ -1,0 +1,45 @@
+using System.Diagnostics;
+
+namespace PaperNexus.Core.Platform;
+
+// Opens folders, files, and URLs in the user's default handler.
+public static class ShellOpener
+{
+    // UseShellExecute routes through the Windows shell and through xdg-open on Linux,
+    // so one call covers both - but only when a desktop portal is present.
+    public static void Open(string target)
+    {
+        try
+        {
+            Process.Start(new ProcessStartInfo(target) { UseShellExecute = true });
+        }
+        catch (Exception) when (OperatingSystem.IsLinux())
+        {
+            // .NET's shell-execute fallback is not available in every Linux session;
+            // invoking xdg-open directly still works wherever xdg-utils is installed.
+            LinuxDesktop.StartDetached("xdg-open", target);
+        }
+        catch (Exception)
+        {
+            // No handler registered - nothing useful to do beyond not crashing the caller.
+        }
+    }
+
+    // Reveals a folder in the platform file manager.
+    public static void OpenFolder(string folderPath)
+    {
+        if (OperatingSystem.IsWindows())
+        {
+            Process.Start(new ProcessStartInfo("explorer.exe", folderPath));
+            return;
+        }
+        Open(folderPath);
+    }
+
+    // Launches another copy of the app (used by the installer hand-off and factory reset).
+    public static void LaunchExecutable(string exePath)
+    {
+        PlatformPaths.EnsureExecutable(exePath);
+        Process.Start(new ProcessStartInfo(exePath) { UseShellExecute = true });
+    }
+}

--- a/PaperNexus/Core/Platform/SingleInstance.cs
+++ b/PaperNexus/Core/Platform/SingleInstance.cs
@@ -1,0 +1,232 @@
+using System.Net.Sockets;
+using System.Runtime.Versioning;
+
+namespace PaperNexus.Core.Platform;
+
+// Enforces one running copy of the app and lets a second launch tell the first to show
+// its window. Named kernel objects do this on Windows; a Unix domain socket does it on
+// Linux, where named EventWaitHandle throws PlatformNotSupportedException.
+public interface ISingleInstance : IDisposable
+{
+    // True when this process took ownership and should run the app.
+    public bool TryAcquire();
+
+    // True when an already-running instance was found and told to show its window.
+    public bool SignalExisting();
+
+    // Blocks on the show-window channel until stopWhen returns true, invoking
+    // onShowRequested for each signal received. Intended to be run on a background thread.
+    public void Listen(Action onShowRequested, Func<bool> stopWhen);
+}
+
+public static class SingleInstance
+{
+    public static ISingleInstance Create()
+    {
+        if (OperatingSystem.IsWindows())
+            return new WindowsSingleInstance();
+        return new UnixSingleInstance();
+    }
+}
+
+[SupportedOSPlatform("windows")]
+internal sealed class WindowsSingleInstance : ISingleInstance
+{
+    private const string EventName = "PaperNexus_ShowUI";
+    private const string MutexName = "PaperNexus_SingleInstance";
+
+    private Mutex? _mutex;
+    private EventWaitHandle? _showEvent;
+
+    public bool TryAcquire()
+    {
+        _mutex = new Mutex(false, MutexName);
+        bool owned;
+        try
+        {
+            owned = _mutex.WaitOne(0, exitContext: false);
+        }
+        catch (AbandonedMutexException)
+        {
+            owned = true; // previous instance crashed; we now own the mutex
+        }
+
+        if (!owned)
+        {
+            _mutex.Dispose();
+            _mutex = null;
+            return false;
+        }
+
+        // AutoReset: each Set() unblocks exactly one WaitOne().
+        _showEvent = new EventWaitHandle(false, EventResetMode.AutoReset, EventName);
+        return true;
+    }
+
+    public bool SignalExisting()
+    {
+        if (!EventWaitHandle.TryOpenExisting(EventName, out var existingEvent))
+            return false;
+        using (existingEvent)
+            existingEvent.Set();
+        return true;
+    }
+
+    public void Listen(Action onShowRequested, Func<bool> stopWhen)
+    {
+        if (_showEvent is null)
+            return;
+
+        // Poll with a 1-second timeout so shutdown is noticed without blocking forever.
+        while (!stopWhen())
+        {
+            try
+            {
+                if (_showEvent.WaitOne(1000) && !stopWhen())
+                    onShowRequested();
+            }
+            catch (ObjectDisposedException)
+            {
+                break;
+            }
+        }
+    }
+
+    public void Dispose()
+    {
+        _showEvent?.Dispose();
+        _showEvent = null;
+        if (_mutex is not null)
+        {
+            try { _mutex.ReleaseMutex(); } catch (ApplicationException) { /* not owned */ }
+            _mutex.Dispose();
+            _mutex = null;
+        }
+    }
+}
+
+// A bound Unix domain socket doubles as the lock and the signalling channel: binding
+// succeeds for exactly one process, and any later process can connect to it to ask the
+// owner to show its window.
+internal sealed class UnixSingleInstance : ISingleInstance
+{
+    private Socket? _listener;
+    private string? _socketPath;
+
+    // XDG_RUNTIME_DIR is per-user and cleared at logout, which is exactly the lifetime
+    // wanted here. /tmp is the fallback when the session manager did not set it.
+    private static string ResolveSocketPath()
+    {
+        var runtimeDir = Environment.GetEnvironmentVariable("XDG_RUNTIME_DIR");
+        if (string.IsNullOrEmpty(runtimeDir) || !Directory.Exists(runtimeDir))
+            runtimeDir = Path.Combine(Path.GetTempPath(), $"papernexus-{Environment.UserName}");
+
+        Directory.CreateDirectory(runtimeDir);
+        return Path.Combine(runtimeDir, "PaperNexus.sock");
+    }
+
+    public bool TryAcquire()
+    {
+        _socketPath = ResolveSocketPath();
+
+        // A socket file left behind by a crashed instance would block binding forever.
+        // Probing it with a connect distinguishes "owner alive" from "stale file".
+        if (File.Exists(_socketPath) && !CanConnect(_socketPath))
+        {
+            try { File.Delete(_socketPath); }
+            catch (IOException) { return false; }
+        }
+
+        try
+        {
+            var listener = new Socket(AddressFamily.Unix, SocketType.Stream, ProtocolType.Unspecified);
+            listener.Bind(new UnixDomainSocketEndPoint(_socketPath));
+            listener.Listen(backlog: 4);
+            _listener = listener;
+            return true;
+        }
+        catch (SocketException)
+        {
+            return false;
+        }
+    }
+
+    private static bool CanConnect(string socketPath)
+    {
+        try
+        {
+            using var probe = new Socket(AddressFamily.Unix, SocketType.Stream, ProtocolType.Unspecified);
+            probe.Connect(new UnixDomainSocketEndPoint(socketPath));
+            return true;
+        }
+        catch (SocketException)
+        {
+            return false;
+        }
+    }
+
+    public bool SignalExisting()
+    {
+        var socketPath = _socketPath ?? ResolveSocketPath();
+        if (!File.Exists(socketPath))
+            return false;
+
+        try
+        {
+            using var client = new Socket(AddressFamily.Unix, SocketType.Stream, ProtocolType.Unspecified);
+            client.Connect(new UnixDomainSocketEndPoint(socketPath));
+            // Connecting is itself the signal; a byte is sent so the owner's blocking
+            // Accept/Receive completes deterministically rather than on socket teardown.
+            client.Send([1]);
+            return true;
+        }
+        catch (SocketException)
+        {
+            return false;
+        }
+    }
+
+    public void Listen(Action onShowRequested, Func<bool> stopWhen)
+    {
+        if (_listener is null)
+            return;
+
+        while (!stopWhen())
+        {
+            try
+            {
+                // Poll so shutdown is noticed even when no second instance ever launches.
+                if (!_listener.Poll(TimeSpan.FromSeconds(1), SelectMode.SelectRead))
+                    continue;
+
+                using var connection = _listener.Accept();
+                if (!stopWhen())
+                    onShowRequested();
+            }
+            catch (ObjectDisposedException)
+            {
+                break;
+            }
+            catch (SocketException)
+            {
+                break;
+            }
+        }
+    }
+
+    public void Dispose()
+    {
+        // Only the process that bound the socket may remove the file. A failed TryAcquire
+        // also records the path, and deleting it there would unbind the live owner.
+        var owned = _listener is not null;
+        _listener?.Dispose();
+        _listener = null;
+
+        if (owned && _socketPath is not null)
+        {
+            try { File.Delete(_socketPath); }
+            catch (IOException) { /* another instance may have already replaced it */ }
+        }
+        _socketPath = null;
+    }
+}

--- a/PaperNexus/Core/Platform/StartupRegistration.cs
+++ b/PaperNexus/Core/Platform/StartupRegistration.cs
@@ -1,0 +1,101 @@
+using System.Runtime.Versioning;
+using Microsoft.Win32;
+
+namespace PaperNexus.Core.Platform;
+
+// Registers or removes "launch PaperNexus at login" using each platform's own mechanism:
+// the HKCU Run key on Windows, an XDG autostart desktop entry on Linux. Both are per-user
+// and need no elevation, which matters on immutable systems such as SteamOS.
+public static class StartupRegistration
+{
+    private const string EntryName = "PaperNexus";
+    private const string RunKeyPath = @"SOFTWARE\Microsoft\Windows\CurrentVersion\Run";
+
+    // Names written by earlier versions of the app, removed on every update so an upgrade
+    // does not leave a second entry pointing at a path that no longer exists.
+    private static readonly string[] LegacyEntryNames =
+    [
+        "Excogitated Wallpaper Service",
+        "Wallpaper Nexus",
+    ];
+
+    // exePath is passed explicitly because the installer must register the *installed*
+    // copy, not the temporary one it is currently running from.
+    public static void Update(bool enable, string? exePath = null)
+    {
+        var target = exePath ?? Environment.ProcessPath;
+        if (string.IsNullOrEmpty(target))
+            return;
+
+        if (OperatingSystem.IsWindows())
+            UpdateWindows(enable, target);
+        else if (OperatingSystem.IsLinux())
+            UpdateLinux(enable, target);
+    }
+
+    [SupportedOSPlatform("windows")]
+    private static void UpdateWindows(bool enable, string exePath)
+    {
+        using var key = Registry.CurrentUser.OpenSubKey(RunKeyPath, writable: true);
+        foreach (var legacyName in LegacyEntryNames)
+            key?.DeleteValue(legacyName, throwOnMissingValue: false);
+
+        if (enable)
+        {
+            // Pass --startup so the app knows it was launched at login rather than by the user.
+            key?.SetValue(EntryName, $"\"{exePath}\" --startup");
+        }
+        else
+        {
+            key?.DeleteValue(EntryName, throwOnMissingValue: false);
+        }
+    }
+
+    // The autostart directory is read by GNOME, KDE Plasma, and every other
+    // freedesktop-compliant session manager at login.
+    private static string AutostartFilePath
+    {
+        get
+        {
+            var configHome = Environment.GetEnvironmentVariable("XDG_CONFIG_HOME");
+            if (string.IsNullOrEmpty(configHome))
+            {
+                var home = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
+                configHome = Path.Combine(home, ".config");
+            }
+            return Path.Combine(configHome, "autostart", $"{EntryName}.desktop");
+        }
+    }
+
+    private static void UpdateLinux(bool enable, string exePath)
+    {
+        var desktopFile = AutostartFilePath;
+
+        if (!enable)
+        {
+            try { File.Delete(desktopFile); }
+            catch (IOException) { /* best-effort - a stale entry only costs an extra launch */ }
+            catch (UnauthorizedAccessException) { /* best-effort */ }
+            return;
+        }
+
+        // Exec values are shell-like: quote the path so directories containing spaces work.
+        var contents = $"""
+            [Desktop Entry]
+            Type=Application
+            Name=PaperNexus
+            Comment=Automated wallpaper rotation
+            Exec="{exePath}" --startup
+            Terminal=false
+            X-GNOME-Autostart-enabled=true
+            """;
+
+        try
+        {
+            Directory.CreateDirectory(Path.GetDirectoryName(desktopFile)!);
+            File.WriteAllText(desktopFile, contents + Environment.NewLine);
+        }
+        catch (IOException) { /* best-effort - startup registration is not critical to run */ }
+        catch (UnauthorizedAccessException) { /* best-effort */ }
+    }
+}

--- a/PaperNexus/Core/WallpaperNexusSettings.cs
+++ b/PaperNexus/Core/WallpaperNexusSettings.cs
@@ -102,7 +102,7 @@ public class AnnotationSettings
 public class DownloadSettings
 {
     public string Folder { get; set; } = Path.Combine(
-        Environment.GetFolderPath(Environment.SpecialFolder.MyPictures), "PaperNexus");
+        PaperNexus.Core.Platform.PlatformPaths.DefaultPicturesDirectory, "PaperNexus");
     public int ResolutionWidth { get; set; } = 0;
     public int ResolutionHeight { get; set; } = 0;
     public int RetentionDays { get; set; } = 365;
@@ -111,8 +111,7 @@ public class DownloadSettings
 public class WallpaperNexusSettings
 {
     public static readonly string SettingsFilePath = Path.Combine(
-        Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
-        "PaperNexus", "settings.json");
+        PaperNexus.Core.Platform.PlatformPaths.DefaultInstallDirectory, "settings.json");
 
     public SlideshowSettings Slideshow { get; set; } = new();
     public DownloadSettings Download { get; set; } = new();

--- a/PaperNexus/NativeMethods.cs
+++ b/PaperNexus/NativeMethods.cs
@@ -1,25 +1,46 @@
 using System.Runtime.InteropServices;
+using System.Runtime.Versioning;
 using Microsoft.Win32;
 using PaperNexus.Core;
+using PaperNexus.Core.Platform;
 
 namespace PaperNexus;
 
-// Abstraction over Windows desktop API calls so tests can run without changing the real wallpaper
+// Abstraction over desktop shell calls so tests can run without changing the real wallpaper
 public interface IWallpaperApplier
 {
     public bool SetWallpaper(string wallpaperPath);
     public void ApplyFillStyle(WallpaperFillStyle style);
 }
 
+// Single registered implementation. It owns no platform logic itself - it picks the
+// backend for the running OS once and forwards every call to it. Keeping one registered
+// type preserves the IAddSingleton auto-discovery contract in Bootstrapper.
 internal sealed class WallpaperApplier : IWallpaperApplier, IAddSingleton<IWallpaperApplier>
+{
+    private readonly IWallpaperBackend _backend = SelectBackend();
+
+    private static IWallpaperBackend SelectBackend()
+    {
+        if (OperatingSystem.IsWindows())
+            return new WindowsWallpaperBackend();
+        if (OperatingSystem.IsLinux())
+            return new LinuxWallpaperBackend();
+        return new NoOpWallpaperBackend();
+    }
+
+    public bool SetWallpaper(string wallpaperPath) => _backend.SetWallpaper(wallpaperPath);
+
+    public void ApplyFillStyle(WallpaperFillStyle style) => _backend.ApplyFillStyle(style);
+}
+
+[SupportedOSPlatform("windows")]
+internal sealed class WindowsWallpaperBackend : IWallpaperBackend
 {
     public bool SetWallpaper(string wallpaperPath) => NativeMethods.SetDesktopWallpaper(wallpaperPath);
 
     public void ApplyFillStyle(WallpaperFillStyle style)
     {
-        if (!OperatingSystem.IsWindows())
-            return;
-
         // WallpaperStyle and TileWallpaper registry values under HKCU\Control Panel\Desktop
         // control how Windows positions the wallpaper image.
         var (wallpaperStyle, tileWallpaper) = style switch
@@ -39,6 +60,7 @@ internal sealed class WallpaperApplier : IWallpaperApplier, IAddSingleton<IWallp
     }
 }
 
+[SupportedOSPlatform("windows")]
 internal static class NativeMethods
 {
     [DllImport("user32.dll", CharSet = CharSet.Unicode)]

--- a/PaperNexus/PaperNexus.csproj
+++ b/PaperNexus/PaperNexus.csproj
@@ -2,13 +2,13 @@
 
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
+    <!-- WinExe suppresses the console window on Windows; on Linux it is treated as Exe. -->
     <TargetFramework>net10.0</TargetFramework>
     <AssemblyName>PaperNexus</AssemblyName>
     <Version>0.0.0</Version>
     <ApplicationIcon>Assets\logo.ico</ApplicationIcon>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
-    <PlatformTarget>x64</PlatformTarget>
     <AvaloniaUseCompiledBindingsByDefault>true</AvaloniaUseCompiledBindingsByDefault>
   </PropertyGroup>
 

--- a/PaperNexus/Program.cs
+++ b/PaperNexus/Program.cs
@@ -7,13 +7,13 @@ global using Newtonsoft.Json;
 global using System.Diagnostics;
 global using System.Reflection;
 global using Avalonia;
+global using PaperNexus.Core.Platform;
 
 internal sealed class Program
 {
-    private const string EventName = "PaperNexus_ShowUI";
-    private const string MutexName = "PaperNexus_SingleInstance";
-
-    internal static EventWaitHandle? ShowUIEvent { get; private set; }
+    // Owns the cross-process lock and the show-window channel for the primary instance.
+    // Null until RunAsPrimaryInstance acquires it, and again after shutdown.
+    internal static ISingleInstance? Instance { get; private set; }
     internal static bool IsDebugMode { get; private set; }
     internal static bool IsInstallMode { get; private set; }
 
@@ -59,14 +59,13 @@ internal sealed class Program
 
     private static (string installDir, string installPath) GetInstallPaths()
     {
-        var path1 = Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData);
-        var installDir = Path.Combine(path1, "PaperNexus");
-        return (installDir, Path.Combine(installDir, "PaperNexus.exe"));
+        var installDir = PlatformPaths.DefaultInstallDirectory;
+        return (installDir, Path.Combine(installDir, PlatformPaths.ExecutableName));
     }
 
     private static string GetCurrentProcessPath()
     {
-        return Environment.ProcessPath ?? Path.Combine(AppContext.BaseDirectory, "PaperNexus.exe");
+        return Environment.ProcessPath ?? Path.Combine(AppContext.BaseDirectory, PlatformPaths.ExecutableName);
     }
 
     private static bool IsRunningFromInstallLocation(string currentPath, string installPath)
@@ -81,7 +80,7 @@ internal sealed class Program
         // Fall back to the default AppData path comparison for existing installations
         // that predate the sentinel file (i.e. installed before this fix was added).
         var install = Path.GetFullPath(installPath);
-        return string.Equals(current, install, StringComparison.OrdinalIgnoreCase);
+        return PlatformPaths.PathEquals(current, install);
     }
 
     // Handles startup when the exe is not yet at the install location.
@@ -93,12 +92,12 @@ internal sealed class Program
             return;
 
         // A previous install may have copied the exe elsewhere and left a redirect marker.
-        // Launch the installed copy instead of showing the install screen again — this
+        // Launch the installed copy instead of showing the install screen again - this
         // prevents an "install loop" when the user re-runs the original downloaded exe.
         if (TryRedirectToInstalledCopy())
             return;
 
-        // Show the install screen — it performs the actual copy and relaunch when confirmed.
+        // Show the install screen - it performs the actual copy and relaunch when confirmed.
         IsInstallMode = true;
         RunApp(args);
     }
@@ -120,12 +119,12 @@ internal sealed class Program
             var installedExe = File.ReadAllText(redirectFile).Trim();
             if (!File.Exists(installedExe))
             {
-                // Installed copy was removed — clean up the stale redirect.
+                // Installed copy was removed - clean up the stale redirect.
                 File.Delete(redirectFile);
                 return false;
             }
 
-            Process.Start(new ProcessStartInfo(installedExe) { UseShellExecute = true });
+            ShellOpener.LaunchExecutable(installedExe);
             return true;
         }
         catch
@@ -149,9 +148,14 @@ internal sealed class Program
             // for locked files (the running exe can't overwrite itself).
             var source = Path.GetFullPath(currentPath);
             var dest = Path.GetFullPath(installPath);
-            var isSamePath = string.Equals(source, dest, StringComparison.OrdinalIgnoreCase);
+            var isSamePath = PlatformPaths.PathEquals(source, dest);
             if (!isSamePath)
+            {
                 File.Copy(currentPath, installPath, overwrite: true);
+                // File.Copy does not carry the Unix execute bit, so the installed copy
+                // would not be launchable on Linux without restoring it.
+                PlatformPaths.EnsureExecutable(installPath);
+            }
 
             // Mark this directory as an install location so startup recognises it
             // regardless of whether it matches the default AppData path.
@@ -165,7 +169,7 @@ internal sealed class Program
                 if (sourceDir is not null)
                 {
                     try { File.WriteAllText(Path.Combine(sourceDir, ".installed-at"), dest); }
-                    catch { /* best-effort — failing just means no redirect */ }
+                    catch { /* best-effort - failing just means no redirect */ }
                 }
             }
             // Carry over persisted data from beside the downloaded exe, if present.
@@ -176,17 +180,17 @@ internal sealed class Program
         catch (IOException)
         {
             // File may be locked by a running instance we could not detect.
-            // The exe might already exist at the install path from a previous install —
+            // The exe might already exist at the install path from a previous install -
             // ensure the sentinel is written so the app won't loop back to the install screen.
             if (!File.Exists(installPath))
                 return false;
             try { File.WriteAllText(Path.Combine(installDir, ".installed"), string.Empty); }
-            catch (IOException) { /* best effort — if this also fails, the install can't complete */ }
+            catch (IOException) { /* best effort - if this also fails, the install can't complete */ }
 
             // Also write the redirect for the source exe.
             var source = Path.GetFullPath(currentPath);
             var dest = Path.GetFullPath(installPath);
-            if (!string.Equals(source, dest, StringComparison.OrdinalIgnoreCase))
+            if (!PlatformPaths.PathEquals(source, dest))
             {
                 var sourceDir = Path.GetDirectoryName(source);
                 if (sourceDir is not null)
@@ -200,47 +204,34 @@ internal sealed class Program
         }
     }
 
-    // Enforces single-instance semantics: acquires the named mutex or signals the
+    // Enforces single-instance semantics: takes the cross-process lock or signals the
     // already-running instance to show its window, then runs the Avalonia app loop.
     private static void RunAsPrimaryInstance(string[] args)
     {
-        using var mutex = new Mutex(false, MutexName);
-        // If we can't own the mutex, another instance is already running.
-        if (!TryAcquireMutex(mutex))
+        var instance = SingleInstance.Create();
+        if (!instance.TryAcquire())
         {
-            TrySignalExistingInstance();
+            // Another instance owns the lock - hand the request over and exit.
+            instance.SignalExisting();
+            instance.Dispose();
             return;
         }
 
-        // Create the IPC event handle for show-UI signals from other instances.
-        // AutoReset: each Set() unblocks exactly one WaitOne().
-        ShowUIEvent = new EventWaitHandle(false, EventResetMode.AutoReset, EventName);
-        RunApp(args);
-        ShowUIEvent.Dispose();
-        ShowUIEvent = null;
-    }
+        Instance = instance;
 
-    private static bool TryAcquireMutex(Mutex mutex)
-    {
-        try
-        {
-            return mutex.WaitOne(0, exitContext: false);
-        }
-        catch (AbandonedMutexException)
-        {
-            return true; // previous instance crashed; we now own the mutex
-        }
+        // The tray "Exit" command calls Environment.Exit, which skips the disposal below,
+        // so release the lock from a process-exit handler as well. Disposal is idempotent.
+        AppDomain.CurrentDomain.ProcessExit += (_, _) => instance.Dispose();
+
+        RunApp(args);
+        Instance = null;
+        instance.Dispose();
     }
 
     private static bool TrySignalExistingInstance()
     {
-#pragma warning disable CA1416
-        if (!EventWaitHandle.TryOpenExisting(EventName, out var existingEvent))
-            return false;
-#pragma warning restore CA1416
-        using (existingEvent)
-            existingEvent.Set();
-        return true;
+        using var probe = SingleInstance.Create();
+        return probe.SignalExisting();
     }
 
     // Wires up global exception logging, then starts the Avalonia application loop.

--- a/PaperNexus/ViewModels/WallpaperConfigViewModel.cs
+++ b/PaperNexus/ViewModels/WallpaperConfigViewModel.cs
@@ -417,9 +417,7 @@ public partial class WallpaperConfigViewModel : ObservableObject
     {
         try
         {
-#pragma warning disable CA1416
-            App.UpdateStartupRegistration(value);
-#pragma warning restore CA1416
+            StartupRegistration.Update(value);
         }
         catch (Exception ex)
         {
@@ -866,7 +864,7 @@ public partial class WallpaperConfigViewModel : ObservableObject
             return;
         try
         {
-            Process.Start(new ProcessStartInfo("explorer.exe", folder) { UseShellExecute = true });
+            ShellOpener.OpenFolder(folder);
         }
         catch (Exception ex)
         {
@@ -920,7 +918,7 @@ public partial class WallpaperConfigViewModel : ObservableObject
             settings.Slideshow.Interval = SlideshowInterval ?? _selectedIntervalType?.Minimum ?? 1;
             settings.Slideshow.IntervalType = _selectedIntervalType?.Type ?? IntervalType.Minutes;
             var cronExpression = BuildSlideshowCronExpression();
-            // Only validate the expression when the user typed it directly — synthesised expressions are always valid
+            // Only validate the expression when the user typed it directly - synthesised expressions are always valid
             if (SlideshowScheduleMode == SlideshowScheduleMode.CronExpression)
             {
                 try
@@ -1198,7 +1196,7 @@ public partial class WallpaperConfigViewModel : ObservableObject
             var wasActive = CurrentWallpaperPath.Equals(item.FilePath, StringComparison.OrdinalIgnoreCase);
             if (wasActive)
             {
-                // The deleted file can no longer be a favorite — clear the heart indicator so
+                // The deleted file can no longer be a favorite - clear the heart indicator so
                 // the UI does not show an empty-path wallpaper as favorited.
                 IsCurrentWallpaperFavorited = false;
 
@@ -1220,7 +1218,7 @@ public partial class WallpaperConfigViewModel : ObservableObject
                     }
                 }
 
-                // No switcher available or no remaining wallpapers — clear the display
+                // No switcher available or no remaining wallpapers - clear the display
                 CurrentWallpaperPath = string.Empty;
                 CurrentWallpaperName = "(none)";
                 RefreshPreviewImage();

--- a/PaperNexus/Views/InstallScreen.axaml.cs
+++ b/PaperNexus/Views/InstallScreen.axaml.cs
@@ -1,7 +1,6 @@
 using Avalonia.Controls;
 using Avalonia.Interactivity;
 using Avalonia.Platform.Storage;
-using Microsoft.Win32;
 using PaperNexus.Core;
 
 namespace PaperNexus.Views;
@@ -33,13 +32,13 @@ public partial class InstallScreen : Window
                 // leaves the original exe behind and causes an install loop.
                 var currentDir = Path.GetDirectoryName(Path.GetFullPath(Program.CurrentExePath));
                 var selectedFull = Path.GetFullPath(selected);
-                if (currentDir is not null && string.Equals(selectedFull, currentDir, StringComparison.OrdinalIgnoreCase))
+                if (currentDir is not null && PlatformPaths.PathEquals(selectedFull, currentDir))
                     InstallPathText.Text = selected;
                 else
                     InstallPathText.Text = Path.Combine(selected, "PaperNexus");
             }
         }
-        catch { /* picker cancelled or unavailable — leave path unchanged */ }
+        catch { /* picker cancelled or unavailable - leave path unchanged */ }
     }
 
     private async void OnInstallClicked(object sender, RoutedEventArgs e)
@@ -54,7 +53,7 @@ public partial class InstallScreen : Window
         var installDir = InstallPathText.Text?.Trim();
         if (string.IsNullOrEmpty(installDir))
             installDir = Program.InstallDir;
-        var installExePath = Path.Combine(installDir, "PaperNexus.exe");
+        var installExePath = Path.Combine(installDir, PlatformPaths.ExecutableName);
 
         try
         {
@@ -64,7 +63,7 @@ public partial class InstallScreen : Window
 
             if (!success)
             {
-                // Install failed — re-enable so the user can try again.
+                // Install failed - re-enable so the user can try again.
                 InstallButton.Content = "Install";
                 InstallButton.IsEnabled = true;
                 CancelButton.IsEnabled = true;
@@ -84,22 +83,14 @@ public partial class InstallScreen : Window
                 await settings.SaveAsync();
             }
 
-            // Always touch the registry during install so a stale entry from a previous
-            // install at a different path doesn't survive and launch the wrong (possibly
-            // missing) exe on Windows startup.
-            // (App.UpdateStartupRegistration uses Environment.ProcessPath which is the
-            // un-installed copy, so we must write the registry entry here ourselves.)
-#pragma warning disable CA1416
-            using var key = Registry.CurrentUser.OpenSubKey(
-                @"SOFTWARE\Microsoft\Windows\CurrentVersion\Run", writable: true);
-            if (RunOnStartupCheckBox.IsChecked == true)
-                key?.SetValue("PaperNexus", $"\"{installExePath}\" --startup");
-            else
-                key?.DeleteValue("PaperNexus", throwOnMissingValue: false);
-#pragma warning restore CA1416
+            // Always rewrite the startup registration during install so a stale entry from
+            // a previous install at a different path doesn't survive and launch the wrong
+            // (possibly missing) executable at login. The installed path is passed
+            // explicitly because Environment.ProcessPath is still the un-installed copy.
+            StartupRegistration.Update(RunOnStartupCheckBox.IsChecked == true, installExePath);
 
             // Launch the newly-installed copy and exit the installer process.
-            Process.Start(new ProcessStartInfo(installExePath) { UseShellExecute = true });
+            ShellOpener.LaunchExecutable(installExePath);
             Environment.Exit(0);
         }
         catch

--- a/PaperNexus/Views/MainWindow.axaml.cs
+++ b/PaperNexus/Views/MainWindow.axaml.cs
@@ -439,14 +439,13 @@ public partial class MainWindow : Window
         {
             var appDir = AppContext.BaseDirectory;
             var exePath = Environment.ProcessPath
-                ?? Path.Combine(appDir, "PaperNexus.exe");
+                ?? Path.Combine(appDir, PlatformPaths.ExecutableName);
 
             // Delete everything in the app directory except the running exe
             foreach (var file in Directory.GetFiles(appDir))
             {
                 // Skip the running exe — it cannot be deleted while in use and is not "data"
-                if (string.Equals(Path.GetFullPath(file), Path.GetFullPath(exePath),
-                    StringComparison.OrdinalIgnoreCase))
+                if (PlatformPaths.PathEquals(Path.GetFullPath(file), Path.GetFullPath(exePath)))
                     continue;
                 try { File.Delete(file); }
                 catch { /* skip locked files */ }
@@ -459,7 +458,7 @@ public partial class MainWindow : Window
             }
 
             // Restart the application
-            Process.Start(new ProcessStartInfo(exePath) { UseShellExecute = true });
+            ShellOpener.LaunchExecutable(exePath);
             Environment.Exit(0);
         }
         catch (Exception ex)

--- a/docs/platform-support.md
+++ b/docs/platform-support.md
@@ -1,0 +1,75 @@
+# Platform Support
+
+PaperNexus runs on Windows and Linux from a single `net10.0` assembly. Every place the two
+operating systems differ is isolated in `PaperNexus/Core/Platform/`; no other file may call
+a Windows-only API, hardcode `.exe`, or compare paths case-insensitively.
+
+## The platform layer
+
+| File | Concern | Windows | Linux |
+| --- | --- | --- | --- |
+| `PlatformPaths.cs` | Executable name, install/pictures directories, path comparison, execute bit | `PaperNexus.exe`, `%LOCALAPPDATA%`, case-insensitive compare | `PaperNexus`, `~/.local/share`, case-sensitive compare, `chmod +x` |
+| `SingleInstance.cs` | One running copy, plus "show the window" from a second launch | Named `Mutex` + named `EventWaitHandle` | Unix domain socket in `$XDG_RUNTIME_DIR` |
+| `StartupRegistration.cs` | Launch at login | `HKCU\...\CurrentVersion\Run` | `~/.config/autostart/PaperNexus.desktop` |
+| `IWallpaperBackend.cs`, `LinuxWallpaperBackend.cs`, `NativeMethods.cs` | Setting the desktop wallpaper and its fill style | `SystemParametersInfo` + `HKCU\Control Panel\Desktop` | KDE Plasma / GNOME / generic setters |
+| `LinuxDesktop.cs` | Desktop environment detection, running helper commands | not used | `XDG_CURRENT_DESKTOP` etc., then process-name inference |
+| `ShellOpener.cs` | Opening folders, URLs, and relaunching the app | `explorer.exe`, shell execute | `xdg-open`, shell execute |
+
+`WallpaperApplier` remains the single type registered for `IWallpaperApplier`, so the
+`IAddSingleton<T>` auto-discovery in `Bootstrapper` still resolves exactly one
+implementation; it selects a backend in its constructor rather than being replaced.
+
+## Setting the wallpaper on Linux
+
+There is no cross-desktop API, so `LinuxWallpaperBackend` dispatches on the detected desktop:
+
+- **KDE Plasma** (the SteamOS Desktop Mode shell) - a JavaScript snippet passed to
+  `org.kde.PlasmaShell.evaluateScript` over D-Bus, tried against `qdbus6`, `qdbus-qt6`,
+  `qdbus`, then `qdbus-qt5`. Falls back to `plasma-apply-wallpaperimage`, which sets the
+  image but not the fill mode.
+- **GNOME** - `gsettings` keys under `org.gnome.desktop.background`. Both `picture-uri` and
+  `picture-uri-dark` are written, otherwise the wallpaper appears unchanged under the dark
+  colour scheme.
+- **Anything else** - `feh`, then `xwallpaper`, then `swaybg` if installed.
+
+Both KDE and GNOME only repaint when the stored value actually changes, and PaperNexus always
+writes the same `current.png`, so each backend clears the key before writing the real path.
+`swaybg` runs for as long as the wallpaper is displayed, so the backend keeps its process and
+terminates the old instance only after the replacement is running.
+
+## Auto-update
+
+The updater looks up a release asset named for the running platform: `PaperNexus.exe` on
+Windows, `PaperNexus-linux-x64` on Linux. Integrity is verified before the binary is ever
+executed:
+
+- Windows - Authenticode signature with subject `CN=PaperNexus`.
+- Linux - SHA-256 digest read from the `PaperNexus-linux-x64.sha256` sidecar asset.
+  Authenticode is a PE-only format, so it cannot be used. **An update with no checksum asset
+  is refused**, so the deploy workflow must keep publishing that file.
+
+The binary swap runs from a self-deleting script - a `.bat` driven by `cmd.exe` on Windows,
+a `.sh` driven by `/bin/sh` on Linux - with the same back up, move, relaunch, verify,
+roll back sequence on both.
+
+## Building and releasing
+
+The deploy workflow publishes a self-contained single-file binary per runtime identifier
+(`win-x64`, `linux-x64`) and attaches three assets to the release: the signed Windows exe,
+the Linux binary, and the Linux checksum.
+
+## Verifying a change locally
+
+This repository is developed on Ubuntu with GNOME; SteamOS Desktop Mode (KDE Plasma) is the
+Linux deployment target. To drive the real desktop from a non-graphical shell, export the
+session's variables before launching:
+
+```bash
+export XDG_RUNTIME_DIR=/run/user/$(id -u)
+export DBUS_SESSION_BUS_ADDRESS=unix:path=$XDG_RUNTIME_DIR/bus
+export DISPLAY=:0 XAUTHORITY=$(pgrep -a Xwayland | grep -o '/run/user/[0-9]*/\.mutter-Xwaylandauth\.[A-Za-z0-9]*')
+dotnet run --project PaperNexus -c Release -- --debug
+```
+
+Confirm the wallpaper actually changed by reading the desktop's own state rather than the
+app's log - `gsettings get org.gnome.desktop.background picture-uri` on GNOME.


### PR DESCRIPTION
Runs PaperNexus on Linux as a supported target (SteamOS Desktop Mode / KDE Plasma), with no change to Windows behaviour.

Every OS difference now lives in `PaperNexus/Core/Platform/`; see `docs/platform-support.md`.

## Blockers fixed
- **Named `EventWaitHandle` threw `PlatformNotSupportedException` on every non-debug launch.** Replaced by a `SingleInstance` abstraction: Mutex + named event on Windows, a Unix domain socket in `$XDG_RUNTIME_DIR` on Linux. Sockets left by a killed process are probed and reclaimed.
- **Unguarded `user32.dll` P/Invoke.** `WallpaperApplier` now selects a backend rather than calling it directly. Linux dispatches to KDE Plasma (`evaluateScript` over D-Bus), GNOME (`gsettings`, both light and dark keys), or `feh`/`xwallpaper`/`swaybg`.
- **Registry writes for launch-at-login.** `StartupRegistration` writes the HKCU Run key on Windows, an XDG autostart entry on Linux.
- **`cmd.exe`/`.bat` auto-update, Authenticode-only verification, `.exe` asset name.** Per-platform asset lookup, a `/bin/sh` swap script, and SHA-256 verification against a published sidecar on Linux - an update with no checksum asset is refused.
- **Case-insensitive path comparison** would conflate distinct wallpapers on Linux; now case-correct per platform.
- **No linux-x64 artifact.** CI publishes both runtime identifiers and attaches the Linux binary plus its checksum.

Also: `File.Copy` does not carry the execute bit, so the installed copy and downloaded update are now `chmod +x`'d; show-window signals post to the UI thread instead of creating a window off-thread.

## Verification
138 tests pass (14 new, none touching the registry or a real desktop). Driven end-to-end on the live Ubuntu 26.04 / GNOME session: app launches, downloads 14 wallpapers, schedules jobs, **sets the real desktop wallpaper** (confirmed by reading `org.gnome.desktop.background picture-uri`, not the app log), installs to `~/.local/share/PaperNexus`, writes the autostart entry, and a second launch signals the first and exits in 0.1s. The updater correctly looked for `PaperNexus-linux-x64` and reported it absent from the current release, which predates this change.

KDE Plasma paths are written from its documented API surface but not yet run against a Plasma session - that needs the Steam Deck.

🤖 Generated with [Claude Code](https://claude.com/claude-code)