### PR TITLE
fix(deps): bump Avalonia to 11.3.18 to clear the Tmds.DBus advisory

### DIFF
--- a/PaperNexus/PaperNexus.csproj
+++ b/PaperNexus/PaperNexus.csproj
@@ -17,11 +17,11 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Avalonia" Version="11.3.12" />
-    <PackageReference Include="Avalonia.Desktop" Version="11.3.12" />
-    <PackageReference Include="Avalonia.Themes.Fluent" Version="11.3.12" />
-    <PackageReference Include="Avalonia.Fonts.Inter" Version="11.3.12" />
-    <PackageReference Include="Avalonia.Diagnostics" Version="11.3.12">
+    <PackageReference Include="Avalonia" Version="11.3.18" />
+    <PackageReference Include="Avalonia.Desktop" Version="11.3.18" />
+    <PackageReference Include="Avalonia.Themes.Fluent" Version="11.3.18" />
+    <PackageReference Include="Avalonia.Fonts.Inter" Version="11.3.18" />
+    <PackageReference Include="Avalonia.Diagnostics" Version="11.3.18">
       <IncludeAssets Condition="'$(Configuration)' != 'Debug'">None</IncludeAssets>
       <PrivateAssets Condition="'$(Configuration)' != 'Debug'">All</PrivateAssets>
     </PackageReference>


### PR DESCRIPTION
Clears **GHSA-xrw6-gwf8-vvr9** (high severity) - *Tmds.DBus: malicious D-Bus peers can spoof signals, exhaust file descriptor resources, and cause denial of service*.

## Why now
`Avalonia 11.3.12` pulled `Tmds.DBus.Protocol` 0.21.2 transitively:

```
Avalonia.Desktop 11.3.12 -> Avalonia.X11 -> Avalonia.FreeDesktop -> Tmds.DBus.Protocol 0.21.2
```

The advisory patches at 0.21.3. This was always present in the dependency graph, but it only started shipping to users in v139, the first release to publish a Linux binary - that build loads the FreeDesktop backend and talks D-Bus.

## The fix
`Avalonia 11.3.18` depends on `Tmds.DBus.Protocol` 0.21.3 directly, so the upstream bump resolves it at source rather than pinning an override on a transitive package.

## Verification
- `dotnet list package --vulnerable --include-transitive` → *no vulnerable packages* for both projects (was: high severity on both).
- Build clean, 138/138 tests pass.
- Launched against the live GNOME session: host started, UI rendered, zero errors or binding failures in the log.

🤖 Generated with [Claude Code](https://claude.com/claude-code)