### PR TITLE
docs: bring the README and CLAUDE.md up to date with Linux support

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -124,9 +124,9 @@ Enforced via `.editorconfig`: .NET 10, C#, file-scoped namespaces, 4-space inden
 - **Deploy workflow:** push to `main`/tags/manual → publish win-x64 and linux-x64 single-file → sign the exe, checksum the Linux binary → GitHub Release with three assets. Self-hosted runner (`[self-hosted, Linux, X64]`); signing uses `openssl` + `osslsigncode` (Linux equivalents of `New-SelfSignedCertificate`/`signtool.exe`).
 - **Version:** Default `0.0.0`, CI sets `-p:Version=$buildNum.0.0`. Tags use `vN` format. Auto-updater compares `Version.Major` as integer.
 - **Code signing:** Self-signed cert, auto-generated on first run, stored as `SIGNING_CERTIFICATE`/`SIGNING_CERTIFICATE_PASSWORD` secrets. Requires `GH_PAT` for persistence. 5-year validity, auto-renews at 30 days remaining.
-- **Publishing:** `dotnet publish PaperNexus/PaperNexus.csproj -c Release -r win-x64 --self-contained true -p:PublishSingleFile=true -p:IncludeNativeLibrariesForSelfExtract=true -p:PublishTrimmed=false`
+- **Publishing:** `dotnet publish PaperNexus/PaperNexus.csproj -c Release -r <win-x64|linux-x64> --self-contained true -p:PublishSingleFile=true -p:IncludeNativeLibrariesForSelfExtract=true -p:PublishTrimmed=false`. The Linux output is renamed to `PaperNexus-linux-x64` because the auto-updater looks the asset up by that exact name.
 - **Self-hosted runner:** Both workflows run on `[self-hosted, Linux, X64]`. The runner has no system .NET SDK and its user cannot write `/usr/share/dotnet`, so every job needs `actions/setup-dotnet@v5` with `DOTNET_INSTALL_DIR: ${{ runner.tool_cache }}/dotnet`. Tools that persist between runs (osslsigncode) are reused rather than reinstalled.
-- **Actions maintenance:** 30-day cycle. **Next update: March 28, 2026.**
+- **Actions maintenance:** 30-day cycle. Currently `actions/checkout@v6`, `actions/setup-dotnet@v5`. **Next update: August 29, 2026.**
 
 ## Guidelines
 

--- a/README.md
+++ b/README.md
@@ -12,12 +12,12 @@
   <a href="https://github.com/0Keith/PaperNexus/releases/latest"><img src="https://img.shields.io/github/v/release/0Keith/PaperNexus?style=flat-square&color=4c9a6e" alt="Latest Release" /></a>
   <a href="https://github.com/0Keith/PaperNexus/blob/main/LICENSE"><img src="https://img.shields.io/github/license/0Keith/PaperNexus?style=flat-square&color=4c9a6e" alt="License" /></a>
   <img src="https://img.shields.io/badge/.NET-10.0-512bd4?style=flat-square" alt=".NET 10" />
-  <img src="https://img.shields.io/badge/platform-Windows-0078d4?style=flat-square" alt="Windows" />
+  <img src="https://img.shields.io/badge/platform-Windows%20%7C%20Linux-0078d4?style=flat-square" alt="Windows and Linux" />
 </p>
 
 ---
 
-PaperNexus is an automated wallpaper rotation app for Windows that lives quietly in your system tray, fetching gorgeous wallpapers and cycling through them on your schedule. Set it, forget it, and enjoy a fresh desktop every time you glance at it.
+PaperNexus is an automated wallpaper rotation app for Windows and Linux that lives quietly in your system tray, fetching gorgeous wallpapers and cycling through them on your schedule. Set it, forget it, and enjoy a fresh desktop every time you glance at it.
 
 ## What It Does
 
@@ -28,13 +28,24 @@ PaperNexus is an automated wallpaper rotation app for Windows that lives quietly
 - **Favorites & bans** — heart a wallpaper to keep it around longer, or ban one you never want to see again
 - **Gallery view** — browse your wallpaper collection, set any as current, or manage favorites/bans
 - **Updates itself** in the background — no manual downloads required
-- **Starts with Windows** so your desktop is never boring, even on a Monday morning
+- **Starts at login** so your desktop is never boring, even on a Monday morning
+- **Runs on Windows and Linux** - KDE Plasma and GNOME are supported directly, with fallbacks for other desktops
 
 ## Quick Start
+
+**Windows**
 
 1. Grab the latest `PaperNexus.exe` from [Releases](https://github.com/0Keith/PaperNexus/releases/latest)
 2. Run it
 3. That's it. You're done. Go get a coffee.
+
+**Linux**
+
+1. Grab `PaperNexus-linux-x64` from [Releases](https://github.com/0Keith/PaperNexus/releases/latest)
+2. `chmod +x PaperNexus-linux-x64 && ./PaperNexus-linux-x64`
+3. Same deal. Coffee time.
+
+The app installs itself to `%LocalAppData%\PaperNexus\` on Windows and `~/.local/share/PaperNexus/` on Linux, then relaunches from there. On Linux it also registers an application launcher, so you can pin it to your dock like anything else.
 
 PaperNexus will park itself in your system tray and start doing its thing. Right-click the tray icon for options:
 
@@ -59,13 +70,16 @@ dotnet build PaperNexus.sln --configuration Release
 # Run it
 dotnet run --project PaperNexus
 
-# Or publish a self-contained exe
+# Or publish a self-contained binary (swap win-x64 for linux-x64)
 dotnet publish PaperNexus/PaperNexus.csproj \
   -c Release -r win-x64 --self-contained true \
   -p:PublishSingleFile=true \
   -p:IncludeNativeLibrariesForSelfExtract=true \
   -p:PublishTrimmed=false
 ```
+
+Running locally? Use `dotnet run --project PaperNexus -- --debug`. Without `--debug` the app
+installs itself and exits, so the window never appears.
 
 Requires [.NET 10 SDK](https://dotnet.microsoft.com/download/dotnet/10.0).
 
@@ -104,17 +118,24 @@ Under the hood, PaperNexus uses scheduled background services to keep everything
 | **Image Processing** | [SixLabors.ImageSharp](https://sixlabors.com/products/imagesharp/) |
 | **Scheduling** | [Cronos](https://github.com/HangfireIO/Cronos) + [CronExpressionDescriptor](https://github.com/bradymholt/cron-expression-descriptor) |
 | **DI & Hosting** | Microsoft.Extensions.Hosting |
+| **Platform layer** | See [docs/platform-support.md](docs/platform-support.md) for how Windows and Linux differ |
 
 ## FAQ
 
-**Q: Does it work on Mac/Linux?**
-A: The UI framework (Avalonia) is cross-platform, but wallpaper-setting uses Windows APIs. So for now, Windows only. PRs welcome though!
+**Q: Does it work on Linux?**
+A: Yes. KDE Plasma (including SteamOS Desktop Mode) and GNOME are driven directly; other desktops fall back to `feh`, `xwallpaper`, or `swaybg` if you have one installed. macOS isn't supported yet - PRs welcome.
+
+**Q: I pinned it to my dock and the icon vanished when I closed it.**
+A: Fixed in v141. Older builds shipped no desktop launcher, so your dock had nothing permanent to pin. Update and it sorts itself out.
 
 **Q: Will it eat my bandwidth?**
 A: Nah. It downloads wallpapers on a schedule (default: once daily from Bing) and caches them locally. Sipping, not chugging.
 
 **Q: SmartScreen is yelling at me!**
-A: The app is signed with a self-signed certificate. SmartScreen calms down after a few people download the same release. Click "More info" > "Run anyway" if you trust us (and you should, the code is right here).
+A: The Windows build is signed with a self-signed certificate. SmartScreen calms down after a few people download the same release. Click "More info" > "Run anyway" if you trust us (and you should, the code is right here).
+
+**Q: How do I know the Linux download isn't tampered with?**
+A: Authenticode is a Windows-only format, so the Linux build ships a `PaperNexus-linux-x64.sha256` alongside it. Run `sha256sum -c PaperNexus-linux-x64.sha256`. The auto-updater checks the same digest and refuses any update it can't verify.
 
 **Q: Can I add my own wallpaper sources?**
 A: Yes! Open Settings, add any HTTP JSON feed URL, and configure the JPath expressions to point at the image URL and title fields. Go wild.
@@ -124,7 +145,7 @@ A: Only if you're concerned about getting bug fixes and features automatically. 
 
 ## Contributing
 
-Found a bug? Have a feature idea? Want to add Linux wallpaper support and become a hero?
+Found a bug? Have a feature idea? Want to add macOS wallpaper support and become a hero?
 
 1. Fork the repo
 2. Create a branch (`git checkout -b my-cool-feature`)


### PR DESCRIPTION
The README still described a Windows-only app three releases after Linux shipped.

## README
- Platform badge said **Windows**; now Windows | Linux.
- Quick Start offered only `PaperNexus.exe`; now covers both binaries and explains where each installs itself.
- Publish command was pinned to `win-x64`, with no mention that `--debug` is needed to run locally.
- FAQ answered *"wallpaper-setting uses Windows APIs, so for now, Windows only"* - now describes the KDE Plasma / GNOME / fallback behaviour, and adds entries for verifying the Linux download's SHA-256 and for the dock-pinning fix in v141.
- Contributing invited someone to *"add Linux wallpaper support and become a hero"*; redirected at macOS.
- Tech stack now links `docs/platform-support.md`.

## CLAUDE.md
- Publish command listed only `win-x64`, and omitted that the Linux output must be renamed to `PaperNexus-linux-x64` for the updater's asset lookup.
- Actions maintenance date (March 28, 2026) had passed; refreshed and pinned to the versions actually in use.

`docs/ui-style-guide.md` was reviewed and needs no change - it covers AXAML patterns, which are platform-neutral.

143/143 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)