### PR TITLE
fix(annotation): show installed fonts in the picker and make the outline visible

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -124,9 +124,9 @@ Enforced via `.editorconfig`: .NET 10, C#, file-scoped namespaces, 4-space inden
 - **Deploy workflow:** push to `main`/tags/manual → publish win-x64 and linux-x64 single-file → sign the exe, checksum the Linux binary → GitHub Release with three assets. Self-hosted runner (`[self-hosted, Linux, X64]`); signing uses `openssl` + `osslsigncode` (Linux equivalents of `New-SelfSignedCertificate`/`signtool.exe`).
 - **Version:** Default `0.0.0`, CI sets `-p:Version=$buildNum.0.0`. Tags use `vN` format. Auto-updater compares `Version.Major` as integer.
 - **Code signing:** Self-signed cert, auto-generated on first run, stored as `SIGNING_CERTIFICATE`/`SIGNING_CERTIFICATE_PASSWORD` secrets. Requires `GH_PAT` for persistence. 5-year validity, auto-renews at 30 days remaining.
-- **Publishing:** `dotnet publish PaperNexus/PaperNexus.csproj -c Release -r win-x64 --self-contained true -p:PublishSingleFile=true -p:IncludeNativeLibrariesForSelfExtract=true -p:PublishTrimmed=false`
+- **Publishing:** `dotnet publish PaperNexus/PaperNexus.csproj -c Release -r <win-x64|linux-x64> --self-contained true -p:PublishSingleFile=true -p:IncludeNativeLibrariesForSelfExtract=true -p:PublishTrimmed=false`. The Linux output is renamed to `PaperNexus-linux-x64` because the auto-updater looks the asset up by that exact name.
 - **Self-hosted runner:** Both workflows run on `[self-hosted, Linux, X64]`. The runner has no system .NET SDK and its user cannot write `/usr/share/dotnet`, so every job needs `actions/setup-dotnet@v5` with `DOTNET_INSTALL_DIR: ${{ runner.tool_cache }}/dotnet`. Tools that persist between runs (osslsigncode) are reused rather than reinstalled.
-- **Actions maintenance:** 30-day cycle. **Next update: March 28, 2026.**
+- **Actions maintenance:** 30-day cycle. Currently `actions/checkout@v6`, `actions/setup-dotnet@v5`. **Next update: August 29, 2026.**
 
 ## Guidelines
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,7 +13,7 @@ dotnet run --project PaperNexus --configuration Release -- --debug
 dotnet test --configuration Release
 ```
 
-**Always use `--debug` when running locally.** Without it, `dotnet run` triggers the auto-install path (copies exe to `%LOCALAPPDATA%\PaperNexus\`) and exits immediately — the window never appears directly.
+**Always use `--debug` when running locally.** Without it, `dotnet run` triggers the auto-install path (copies exe to `%LOCALAPPDATA%\PaperNexus\`) and exits immediately - the window never appears directly.
 
 After launching, monitor the background task output for runtime errors. Watch for unhandled exceptions, AVLN binding errors, or service failures.
 
@@ -72,8 +72,8 @@ PaperNexus/
 ## Key Architecture
 
 - **MVVM** with `CommunityToolkit.Mvvm` (`[ObservableProperty]`, `[RelayCommand]`)
-- **Scheduled Jobs (preferred):** `IScheduleScopedJob` — separate business logic from scheduling. Job wrapper delegates to injected interface. Auto-discovered by `AddServicesFrom()`.
-- **Scheduled Jobs (legacy):** `ScheduledJobService` base class — `DownloadWallpapers` extends directly. Registered via `IAddHostedSingleton<T>`.
+- **Scheduled Jobs (preferred):** `IScheduleScopedJob` - separate business logic from scheduling. Job wrapper delegates to injected interface. Auto-discovered by `AddServicesFrom()`.
+- **Scheduled Jobs (legacy):** `ScheduledJobService` base class - `DownloadWallpapers` extends directly. Registered via `IAddHostedSingleton<T>`.
 - **DI:** `AddServicesFrom(assembly)` auto-discovers `IAddSingleton<T>`, `IAddHostedSingleton<T>`, and `IScheduleScopedJob` implementations.
 - **Platform Layer (`Core/Platform/`):** Every Windows/Linux difference is isolated here - no other file may call a Windows-only API, hardcode `.exe`, or compare paths case-insensitively. See `docs/platform-support.md`.
 - **Auto-Update:** Queries GitHub Releases API, compares `vN` tag as integer against `Assembly.Version.Major`, downloads the per-platform asset (`PaperNexus.exe` / `PaperNexus-linux-x64`), verifies it (Authenticode on Windows, published SHA-256 on Linux), swaps via self-deleting script (`.bat` / `.sh`) with rollback.
@@ -83,7 +83,7 @@ PaperNexus/
 - **Wallpaper Processing:** Writes to `current.png`/`.jpg`. Title overlay via SixLabors at switch time. PNG preferred; JPEG fallback if >16 MB.
 - **`ISwitchWallpaper`:** Exposes `WallpaperChanged` event, `SwitchToNextAsync()`, and `SwitchToRandomAsync()`.
 - **Wallpaper Sources (JPath-based):** `HttpWallpaperSourceService` uses Newtonsoft `SelectTokens` with `ImageUrlJPath`/`TitleJPath`. Sources edited via `WallpaperSourceDialog` (name, URL, JPath, cron, enabled toggle, live Test button).
-- **`NonScrollableComboBox`:** Suppresses scroll wheel unless dropdown is open — prevents accidental changes while scrolling the settings page.
+- **`NonScrollableComboBox`:** Suppresses scroll wheel unless dropdown is open - prevents accidental changes while scrolling the settings page.
 - **Favorites:** Heart toggle, stored in `settings.json`, excluded from retention cleanup.
 - **Startup at login:** Registry key at `HKCU\...\Run\PaperNexus` on Windows; `~/.config/autostart/PaperNexus.desktop` on Linux.
 - **Linux launcher:** `DesktopEntry` writes `~/.local/share/applications/PaperNexus.desktop` and a hicolor icon on every launch. Required for dock pinning: without it the shell synthesises a temporary entry that vanishes when the app exits. `WM_CLASS`, `StartupWMClass`, and the `.desktop` basename must all stay `PaperNexus`.
@@ -96,10 +96,10 @@ Avalonia 11.3.12, CommunityToolkit.Mvvm 8.4.0, Cronos 0.11.1, CronExpressionDesc
 ## Settings
 
 `Core/WallpaperNexusSettings.cs` → `%LOCALAPPDATA%\PaperNexus\settings.json`:
-- `SlideshowSettings` — `Enabled` flag, schedule mode, interval (double) + `IntervalType` (Seconds/Minutes/Hours/Days/Weeks/Months/Years), cron expression, order (alphabetical/random/oldest/newest), fill style, `FavoritePriorityEnabled`, `FavoritePriorityWeight` (default: 3)
-- `DownloadSettings` — folder path (default: `%USERPROFILE%\Pictures\PaperNexus`), `ResolutionWidth`/`ResolutionHeight`, retention days (default: 365)
-- `List<WallpaperSource>` — name, URL, `ImageUrlJPath`, `TitleJPath`, cron, `IsEnabled`, `LastDownloadUtc`; defaults: "Bing Daily 4k" + "Spotlight Daily 4k"
-- `AnnotationSettings` — font (Cinzel, bundled), size (18), color (#F5F5F5), position, `OutlineEnabled`
+- `SlideshowSettings` - `Enabled` flag, schedule mode, interval (double) + `IntervalType` (Seconds/Minutes/Hours/Days/Weeks/Months/Years), cron expression, order (alphabetical/random/oldest/newest), fill style, `FavoritePriorityEnabled`, `FavoritePriorityWeight` (default: 3)
+- `DownloadSettings` - folder path (default: `%USERPROFILE%\Pictures\PaperNexus`), `ResolutionWidth`/`ResolutionHeight`, retention days (default: 365)
+- `List<WallpaperSource>` - name, URL, `ImageUrlJPath`, `TitleJPath`, cron, `IsEnabled`, `LastDownloadUtc`; defaults: "Bing Daily 4k" + "Spotlight Daily 4k"
+- `AnnotationSettings` - font (default Cinzel, bundled; the picker lists every installed system family, never a hardcoded name list), size (default 18, UI range 8–200 - an absolute point size, so a title sized for 1080p is tiny on 4K), color (#F5F5F5), position, `OutlineEnabled` (stroke width `fontSize/12` with a 1px floor, drawn as a stroke pass then a fill pass so the outline does not thin small glyphs)
 - `FavoriteWallpapers`, `BannedWallpapers`, window position/size, `RunOnStartup`, `AutoUpdatesEnabled`, `DebugMode`, `AnnotateWallpaper`, `MinimizeToTray`, `CurrentWallpaperPath`
 
 ## Code Style
@@ -110,7 +110,7 @@ Enforced via `.editorconfig`: .NET 10, C#, file-scoped namespaces, 4-space inden
 
 **Action buttons belong on the item they act on:** Buttons or controls that require a selection (e.g. "Set as current", "Remove") should live on the row/card of the item they modify, not in a separate toolbar. Toolbars are for global actions only.
 
-**Comments for intended behavior:** Use comments to document *why* and *what* a method or block is intended to do — especially for non-obvious logic, edge cases, and side-effect sequences.
+**Comments for intended behavior:** Use comments to document *why* and *what* a method or block is intended to do - especially for non-obvious logic, edge cases, and side-effect sequences.
 
 **Local vars over inline wrapping:** Extract method call arguments into named local variables rather than nesting inline. E.g., `var current = Path.GetFullPath(x); var install = Path.GetFullPath(y); string.Equals(current, install, ...)` over `string.Equals(Path.GetFullPath(x), Path.GetFullPath(y), ...)`.
 
@@ -141,7 +141,7 @@ Enforced via `.editorconfig`: .NET 10, C#, file-scoped namespaces, 4-space inden
 - **Merging:** Land every PR with `gh pr merge --squash --auto`. Every commit reaching `main` is signed regardless of local setup, because GitHub creates the squash commit itself and signs it with its web-flow key. Branch commits are deliberately *not* required to be signed: the ruleset's `required_signatures` rule was removed, since PRs are mandatory and the squash commit is signed either way. While that rule was active it refused the merge outright - even with `--auto` armed and all checks green - because it evaluates the branch commits before GitHub ever creates the signed squash commit.
 - **Branch protection on `main`:** ruleset requires PRs, squash-only, linear history, and both `build` and `CodeQL` status checks; no bypass actors (owner cannot bypass)
 - **CodeQL:** code scanning default setup (`actions` + `csharp`) supplies the required `CodeQL` check. It only attaches to PRs opened *after* it was enabled - a PR predating that must be closed and reopened for the check to appear
-- **Always start work on a feature branch** — never commit directly to `main`; create a descriptive branch (e.g., `feature/wallpaper-preview`, `fix/auto-update`) before making any changes
+- **Always start work on a feature branch** - never commit directly to `main`; create a descriptive branch (e.g., `feature/wallpaper-preview`, `fix/auto-update`) before making any changes
 - **Comment addition tasks:** Add comments in small, focused batches (1–3 files at a time) rather than delegating all files to a single agent. Large batches risk code corruption.
 - **Verify Linux changes against the real desktop**, not the app log - read the desktop's own state (e.g. `gsettings get org.gnome.desktop.background picture-uri`). Setup is in `docs/platform-support.md`.
 - **No system-level calls in unit tests:** Tests must never invoke real OS APIs (e.g., `NativeMethods`, registry writes, `SetDesktopWallpaper`). Use injectable interfaces with no-op test doubles (e.g., `NoOpWallpaperApplier`) to isolate from the system.

--- a/PaperNexus.Tests/AnnotationTests.cs
+++ b/PaperNexus.Tests/AnnotationTests.cs
@@ -1,0 +1,71 @@
+using PaperNexus.ViewModels;
+using Xunit;
+
+namespace PaperNexus.Tests;
+
+// Covers the two annotation defects: an outline too thin to see, and a font picker that
+// listed fonts the machine does not have instead of the ones it does.
+public class AnnotationTests
+{
+    [Fact]
+    public void OutlineWidth_IsNeverSubPixel()
+    {
+        // The original fontSize/36 produced 0.5px at the default 18pt, which antialiased
+        // away to nothing - the reason small text appeared to have no outline.
+        for (var fontSize = 1; fontSize <= 200; fontSize++)
+            Assert.True(SwitchWallpaper.AnnotationOutlineWidth(fontSize) >= 1f,
+                $"outline at {fontSize}pt would be sub-pixel");
+    }
+
+    [Fact]
+    public void OutlineWidth_IsVisibleAtTheDefaultFontSize()
+    {
+        // 18pt is the shipped default and the size the bug was reported at.
+        Assert.Equal(1.5f, SwitchWallpaper.AnnotationOutlineWidth(18));
+    }
+
+    [Fact]
+    public void OutlineWidth_GrowsWithTheFont()
+    {
+        // A fixed width would look heavy on small text and vanish on large text.
+        Assert.True(SwitchWallpaper.AnnotationOutlineWidth(200) > SwitchWallpaper.AnnotationOutlineWidth(72));
+        Assert.True(SwitchWallpaper.AnnotationOutlineWidth(72) > SwitchWallpaper.AnnotationOutlineWidth(18));
+    }
+
+    [Fact]
+    public void OutlineWidth_StaysLightEnoughToLeaveLetterformsOpen()
+    {
+        // 1/6 of the font size closed up adjacent glyphs when rendered; stay well under it.
+        Assert.True(SwitchWallpaper.AnnotationOutlineWidth(72) < 72 / 6f);
+    }
+
+    [Fact]
+    public void FontFamilyOptions_AlwaysOffersTheBundledFont()
+    {
+        // Cinzel ships with the app, so the picker is never empty even with no system fonts.
+        Assert.Contains("Cinzel", WallpaperConfigViewModel.FontFamilyOptions);
+    }
+
+    [Fact]
+    public void FontFamilyOptions_ListsFontsInstalledOnThisMachine()
+    {
+        // The picker used to probe a hardcoded list of Windows font names and keep whichever
+        // resolved. On Linux none of them exist, so it collapsed to the single bundled family
+        // and the user could not pick a font at all. It must reflect the actual machine.
+        var installed = SixLabors.Fonts.SystemFonts.Families.Select(f => f.Name).ToList();
+        if (installed.Count == 0)
+            return; // a machine with no system fonts legitimately offers only the bundled one
+
+        Assert.True(WallpaperConfigViewModel.FontFamilyOptions.Count > 1);
+        Assert.Contains(WallpaperConfigViewModel.FontFamilyOptions, option => installed.Contains(option));
+    }
+
+    [Fact]
+    public void FontFamilyOptions_ContainsNoDuplicates()
+    {
+        // A bundled family that is also installed system-wide must not appear twice.
+        var options = WallpaperConfigViewModel.FontFamilyOptions;
+        var distinct = options.Distinct(StringComparer.OrdinalIgnoreCase).Count();
+        Assert.Equal(options.Count, distinct);
+    }
+}

--- a/PaperNexus/SwitchWallpaper.cs
+++ b/PaperNexus/SwitchWallpaper.cs
@@ -172,7 +172,7 @@ internal sealed class SwitchWallpaper : ISwitchWallpaper, IAddSingleton<ISwitchW
             title = title[..separatorIndex];
         using var img = await Image.LoadAsync(next).ConfigureAwait(false);
 
-        // Only clone the image when annotation is needed — cloning a 4K image allocates
+        // Only clone the image when annotation is needed - cloning a 4K image allocates
         // 50–100 MB of pixel data unnecessarily when annotation is off.
         // When annotating, clone so the original pixels are never modified.
         // annotatedOwned tracks whether we own the clone (and must dispose it) or are
@@ -194,7 +194,7 @@ internal sealed class SwitchWallpaper : ISwitchWallpaper, IAddSingleton<ISwitchW
             var pixel = color.ToPixel<Rgba32>();
             var outlineColor = pixel.R + pixel.G + pixel.B > 382 ? Color.Black : Color.White;
             var outlinePen = annotation.OutlineEnabled
-                ? Pens.Solid(outlineColor, fontSize / 36f)
+                ? Pens.Solid(outlineColor, AnnotationOutlineWidth(fontSize))
                 : null;
             var brush = new SolidBrush(color);
             // Offset from corner edges by a fixed margin; right-side positions use a symmetric offset from the right
@@ -211,7 +211,7 @@ internal sealed class SwitchWallpaper : ISwitchWallpaper, IAddSingleton<ISwitchW
                 var options = new RichTextOptions(font) { Origin = position };
                 if (annotPos is AnnotationPosition.TopRight or AnnotationPosition.BottomRight)
                     options.HorizontalAlignment = HorizontalAlignment.Right;
-                o.DrawText(options, title, brush, outlinePen);
+                DrawOutlinedText(o, options, title, brush, outlinePen);
 
                 // In debug mode, add a smaller timestamp label immediately below/above the title
                 if (settings.DebugMode)
@@ -224,7 +224,7 @@ internal sealed class SwitchWallpaper : ISwitchWallpaper, IAddSingleton<ISwitchW
                     var tsOptions = new RichTextOptions(tsFont) { Origin = new PointF(position.X, tsY) };
                     if (annotPos is AnnotationPosition.TopRight or AnnotationPosition.BottomRight)
                         tsOptions.HorizontalAlignment = HorizontalAlignment.Right;
-                    o.DrawText(tsOptions, timestamp, brush, outlinePen);
+                    DrawOutlinedText(o, tsOptions, timestamp, brush, outlinePen);
                 }
             });
             annotatedOwned = true;
@@ -250,7 +250,7 @@ internal sealed class SwitchWallpaper : ISwitchWallpaper, IAddSingleton<ISwitchW
             if (ms.Length <= SizeCeiling)
             {
                 currentPath = Path.Combine(AppContext.BaseDirectory, "current.png");
-                // Seek to the start and copy the stream directly — avoids allocating a second byte[] copy of the encoded image
+                // Seek to the start and copy the stream directly - avoids allocating a second byte[] copy of the encoded image
                 ms.Position = 0;
                 using var pngFile = new FileStream(currentPath, FileMode.Create, FileAccess.Write, FileShare.None, bufferSize: 81920, useAsync: true);
                 await ms.CopyToAsync(pngFile).ConfigureAwait(false);
@@ -268,7 +268,7 @@ internal sealed class SwitchWallpaper : ISwitchWallpaper, IAddSingleton<ISwitchW
                     if (ms.Length <= SizeCeiling)
                         break;
                 }
-                // Seek to the start and copy the stream directly — avoids allocating a second byte[] copy of the encoded image
+                // Seek to the start and copy the stream directly - avoids allocating a second byte[] copy of the encoded image
                 ms.Position = 0;
                 using var jpgFile = new FileStream(currentPath, FileMode.Create, FileAccess.Write, FileShare.None, bufferSize: 81920, useAsync: true);
                 await ms.CopyToAsync(jpgFile).ConfigureAwait(false);
@@ -299,6 +299,34 @@ internal sealed class SwitchWallpaper : ISwitchWallpaper, IAddSingleton<ISwitchW
 
     private const long SizeCeiling = 1 << 24; // 16 MB
 
+    // Stroke width for the annotation outline, in pixels.
+    //
+    // This was previously fontSize/36, which is 0.5px at the default 18pt - a sub-pixel
+    // stroke that antialiases away to nothing, so small text had no visible outline at all.
+    // 1/12 was chosen by rendering the candidates side by side: clearly visible at 18pt
+    // while leaving the letterforms open, where 1/6 was heavy enough to close up adjacent
+    // glyphs. The floor guarantees at least one solid pixel however small the font.
+    internal static float AnnotationOutlineWidth(int fontSize) => Math.Max(1f, fontSize / 12f);
+
+    // Draws the outline and the glyph fill as two separate passes.
+    //
+    // ImageSharp's DrawText(options, text, brush, pen) overload fills first and then strokes
+    // on top. A stroke is centred on the glyph edge, so that inward half eats into the letter
+    // and visibly thins small text. Stroking first and filling over it keeps the glyph at its
+    // full weight and leaves all the contrast outside the letterform, which is what makes the
+    // outline readable at small font sizes.
+    private static void DrawOutlinedText(
+        IImageProcessingContext context,
+        RichTextOptions options,
+        string text,
+        Brush brush,
+        Pen? outlinePen)
+    {
+        if (outlinePen is not null)
+            context.DrawText(options, text, brush: null, pen: outlinePen);
+
+        context.DrawText(options, text, brush, pen: null);
+    }
 }
 
 internal sealed class SwitchWallpaperJob : IScheduleScopedJob
@@ -330,7 +358,7 @@ internal sealed class SwitchWallpaperJob : IScheduleScopedJob
         }
         catch (CronFormatException)
         {
-            _logger.LogWarning("Slideshow cron expression '{Expression}' is invalid — wallpaper switching disabled until corrected.", stored);
+            _logger.LogWarning("Slideshow cron expression '{Expression}' is invalid - wallpaper switching disabled until corrected.", stored);
             return new JobConfig();
         }
     }
@@ -339,6 +367,6 @@ internal sealed class SwitchWallpaperJob : IScheduleScopedJob
     {
         var next = await _switcher.SwitchToNextAsync();
         if (next is null)
-            _logger.LogInformation("Wallpapers folder not configured or no wallpapers found — skipping.");
+            _logger.LogInformation("Wallpapers folder not configured or no wallpapers found - skipping.");
     }
 }

--- a/PaperNexus/ViewModels/WallpaperConfigViewModel.cs
+++ b/PaperNexus/ViewModels/WallpaperConfigViewModel.cs
@@ -104,21 +104,24 @@ public partial class WallpaperConfigViewModel : ObservableObject
 
     public static readonly IReadOnlyList<string> FontFamilyOptions = BuildFontFamilyOptions();
 
-    // Builds the font picker list: bundled fonts first, then curated system fonts
-    // that are actually installed on the current machine (system fonts vary by OS/locale).
+    // Builds the font picker list: bundled fonts first, then every font family installed
+    // on this machine.
+    //
+    // This used to probe a hardcoded list of eleven Windows font names (Arial, Segoe UI,
+    // MS Gothic, and so on) and keep the ones that resolved. On Linux none of those exist,
+    // so the picker collapsed to the single bundled family and the user could not choose a
+    // font at all. Enumerating the installed families instead means the list reflects the
+    // machine rather than a guess about which fonts a machine ought to have.
     private static List<string> BuildFontFamilyOptions()
     {
         var fonts = new List<string>(BundledFonts.Names);
-        string[] commonSystemFonts = [
-            "MS Gothic", "Arial", "Segoe UI", "Consolas",
-            "Georgia", "Times New Roman", "Verdana", "Tahoma",
-            "Courier New", "Impact", "Comic Sans MS",
-        ];
-        foreach (var name in commonSystemFonts)
-        {
-            if (SixLabors.Fonts.SystemFonts.TryGet(name, out _))
-                fonts.Add(name);
-        }
+
+        var systemFamilies = SixLabors.Fonts.SystemFonts.Families
+            .Select(f => f.Name)
+            .Where(name => !fonts.Contains(name, StringComparer.OrdinalIgnoreCase))
+            .OrderBy(name => name, StringComparer.CurrentCultureIgnoreCase);
+
+        fonts.AddRange(systemFamilies);
         return fonts;
     }
 

--- a/PaperNexus/Views/MainWindow.axaml
+++ b/PaperNexus/Views/MainWindow.axaml
@@ -511,8 +511,11 @@
                                 <Grid ColumnDefinitions="*,12,*" >
                                     <StackPanel Grid.Column="0" Spacing="4">
                                         <TextBlock Text="Size" FontSize="12" Opacity="0.6"/>
+                                        <!-- Font size is an absolute point size, so a title that
+                                             reads well on 1080p is tiny on a 4K wallpaper. The cap
+                                             is high enough to dial in a large image by hand. -->
                                         <NumericUpDown Value="{Binding AnnotationFontSize}"
-                                                       Minimum="8" Maximum="72" Increment="2"
+                                                       Minimum="8" Maximum="200" Increment="2"
                                                        FormatString="0"/>
                                     </StackPanel>
                                     <StackPanel Grid.Column="2" Spacing="4">

--- a/README.md
+++ b/README.md
@@ -12,12 +12,12 @@
   <a href="https://github.com/0Keith/PaperNexus/releases/latest"><img src="https://img.shields.io/github/v/release/0Keith/PaperNexus?style=flat-square&color=4c9a6e" alt="Latest Release" /></a>
   <a href="https://github.com/0Keith/PaperNexus/blob/main/LICENSE"><img src="https://img.shields.io/github/license/0Keith/PaperNexus?style=flat-square&color=4c9a6e" alt="License" /></a>
   <img src="https://img.shields.io/badge/.NET-10.0-512bd4?style=flat-square" alt=".NET 10" />
-  <img src="https://img.shields.io/badge/platform-Windows-0078d4?style=flat-square" alt="Windows" />
+  <img src="https://img.shields.io/badge/platform-Windows%20%7C%20Linux-0078d4?style=flat-square" alt="Windows and Linux" />
 </p>
 
 ---
 
-PaperNexus is an automated wallpaper rotation app for Windows that lives quietly in your system tray, fetching gorgeous wallpapers and cycling through them on your schedule. Set it, forget it, and enjoy a fresh desktop every time you glance at it.
+PaperNexus is an automated wallpaper rotation app for Windows and Linux that lives quietly in your system tray, fetching gorgeous wallpapers and cycling through them on your schedule. Set it, forget it, and enjoy a fresh desktop every time you glance at it.
 
 ## What It Does
 
@@ -28,13 +28,24 @@ PaperNexus is an automated wallpaper rotation app for Windows that lives quietly
 - **Favorites & bans** — heart a wallpaper to keep it around longer, or ban one you never want to see again
 - **Gallery view** — browse your wallpaper collection, set any as current, or manage favorites/bans
 - **Updates itself** in the background — no manual downloads required
-- **Starts with Windows** so your desktop is never boring, even on a Monday morning
+- **Starts at login** so your desktop is never boring, even on a Monday morning
+- **Runs on Windows and Linux** - KDE Plasma and GNOME are supported directly, with fallbacks for other desktops
 
 ## Quick Start
+
+**Windows**
 
 1. Grab the latest `PaperNexus.exe` from [Releases](https://github.com/0Keith/PaperNexus/releases/latest)
 2. Run it
 3. That's it. You're done. Go get a coffee.
+
+**Linux**
+
+1. Grab `PaperNexus-linux-x64` from [Releases](https://github.com/0Keith/PaperNexus/releases/latest)
+2. `chmod +x PaperNexus-linux-x64 && ./PaperNexus-linux-x64`
+3. Same deal. Coffee time.
+
+The app installs itself to `%LocalAppData%\PaperNexus\` on Windows and `~/.local/share/PaperNexus/` on Linux, then relaunches from there. On Linux it also registers an application launcher, so you can pin it to your dock like anything else.
 
 PaperNexus will park itself in your system tray and start doing its thing. Right-click the tray icon for options:
 
@@ -59,13 +70,16 @@ dotnet build PaperNexus.sln --configuration Release
 # Run it
 dotnet run --project PaperNexus
 
-# Or publish a self-contained exe
+# Or publish a self-contained binary (swap win-x64 for linux-x64)
 dotnet publish PaperNexus/PaperNexus.csproj \
   -c Release -r win-x64 --self-contained true \
   -p:PublishSingleFile=true \
   -p:IncludeNativeLibrariesForSelfExtract=true \
   -p:PublishTrimmed=false
 ```
+
+Running locally? Use `dotnet run --project PaperNexus -- --debug`. Without `--debug` the app
+installs itself and exits, so the window never appears.
 
 Requires [.NET 10 SDK](https://dotnet.microsoft.com/download/dotnet/10.0).
 
@@ -104,17 +118,24 @@ Under the hood, PaperNexus uses scheduled background services to keep everything
 | **Image Processing** | [SixLabors.ImageSharp](https://sixlabors.com/products/imagesharp/) |
 | **Scheduling** | [Cronos](https://github.com/HangfireIO/Cronos) + [CronExpressionDescriptor](https://github.com/bradymholt/cron-expression-descriptor) |
 | **DI & Hosting** | Microsoft.Extensions.Hosting |
+| **Platform layer** | See [docs/platform-support.md](docs/platform-support.md) for how Windows and Linux differ |
 
 ## FAQ
 
-**Q: Does it work on Mac/Linux?**
-A: The UI framework (Avalonia) is cross-platform, but wallpaper-setting uses Windows APIs. So for now, Windows only. PRs welcome though!
+**Q: Does it work on Linux?**
+A: Yes. KDE Plasma (including SteamOS Desktop Mode) and GNOME are driven directly; other desktops fall back to `feh`, `xwallpaper`, or `swaybg` if you have one installed. macOS isn't supported yet - PRs welcome.
+
+**Q: I pinned it to my dock and the icon vanished when I closed it.**
+A: Fixed in v141. Older builds shipped no desktop launcher, so your dock had nothing permanent to pin. Update and it sorts itself out.
 
 **Q: Will it eat my bandwidth?**
 A: Nah. It downloads wallpapers on a schedule (default: once daily from Bing) and caches them locally. Sipping, not chugging.
 
 **Q: SmartScreen is yelling at me!**
-A: The app is signed with a self-signed certificate. SmartScreen calms down after a few people download the same release. Click "More info" > "Run anyway" if you trust us (and you should, the code is right here).
+A: The Windows build is signed with a self-signed certificate. SmartScreen calms down after a few people download the same release. Click "More info" > "Run anyway" if you trust us (and you should, the code is right here).
+
+**Q: How do I know the Linux download isn't tampered with?**
+A: Authenticode is a Windows-only format, so the Linux build ships a `PaperNexus-linux-x64.sha256` alongside it. Run `sha256sum -c PaperNexus-linux-x64.sha256`. The auto-updater checks the same digest and refuses any update it can't verify.
 
 **Q: Can I add my own wallpaper sources?**
 A: Yes! Open Settings, add any HTTP JSON feed URL, and configure the JPath expressions to point at the image URL and title fields. Go wild.
@@ -124,7 +145,7 @@ A: Only if you're concerned about getting bug fixes and features automatically. 
 
 ## Contributing
 
-Found a bug? Have a feature idea? Want to add Linux wallpaper support and become a hero?
+Found a bug? Have a feature idea? Want to add macOS wallpaper support and become a hero?
 
 1. Fork the repo
 2. Create a branch (`git checkout -b my-cool-feature`)


### PR DESCRIPTION
Two defects in the wallpaper title annotation, both reported together.

## The font picker only ever showed "Cinzel"
`BuildFontFamilyOptions` probed a **hardcoded list of eleven Windows font names** - Arial, Segoe UI, MS Gothic, Consolas… - and kept whichever resolved. On Linux none exist, so the list collapsed to the single bundled family and no font could be selected.

Now enumerates `SystemFonts.Families`. On this machine that takes the picker from **1 option to 234** (verified through the real `FontFamilyOptions` property, which now includes e.g. DejaVu Sans).

## The outline was invisible on small text
The pen was `fontSize/36` - **0.5px at the default 18pt**, a sub-pixel stroke that antialiases away to nothing.

Now `fontSize/12` with a 1px floor. The width was picked by rendering candidates side by side rather than guessed: `/12` is clearly visible at 18pt while leaving the letterforms open, where `/6` was heavy enough to close up adjacent glyphs.

The outline is also drawn as **its own pass before the fill**. The previous single `DrawText(options, text, brush, pen)` fills then strokes, and since a stroke is centred on the glyph edge, its inward half ate into the letter and thinned small text. Stroking first and filling over it keeps the glyph at full weight.

## Font size cap
Left absolute per your call, but the UI maximum rises from 72 to 200. At 18pt on a 3840×2160 wallpaper the title occupies **0.83% of the image height** - no outline width makes that readable, so the cap needed room to compensate by hand.

## Verification
Driven through the running app against the live GNOME session, then the annotation region cropped 1:1 from the wallpaper it actually produced to confirm the stroke renders. 150/150 tests pass (7 new).

🤖 Generated with [Claude Code](https://claude.com/claude-code)