### PR TITLE
chore(deps): bump actions/checkout to v7 and CommunityToolkit.Mvvm to 8.4.2

### DIFF
--- a/.github/workflows/deploy-wallpaper-service.yml
+++ b/.github/workflows/deploy-wallpaper-service.yml
@@ -16,7 +16,7 @@ jobs:
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@v6
+      uses: actions/checkout@v7
 
     # The self-hosted runner has no system-wide .NET software development kit,
     # and the unprivileged runner user cannot create the default /usr/share/dotnet

--- a/.github/workflows/deploy-website.yml
+++ b/.github/workflows/deploy-website.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     name: Deploy to Azure Static Web Apps
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       - name: Deploy
         uses: Azure/static-web-apps-deploy@v1

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -13,7 +13,7 @@ jobs:
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@v6
+      uses: actions/checkout@v7
 
     # The self-hosted runner has no system-wide .NET software development kit,
     # and the unprivileged runner user cannot create the default /usr/share/dotnet

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -29,7 +29,8 @@ PaperNexus/
 ├── .github/
 │   └── workflows/
 │       ├── pull-request.yml             # PR build verification
-│       └── deploy-wallpaper-service.yml # Release builds + code signing
+│       ├── deploy-wallpaper-service.yml # Release builds + code signing
+│       └── deploy-website.yml           # Azure Static Web Apps deploy (website/ only)
 ├── docs/
 │   ├── ui-style-guide.md               # Avalonia AXAML patterns reference
 │   └── platform-support.md             # Windows/Linux platform layer reference
@@ -125,7 +126,8 @@ Enforced via `.editorconfig`: .NET 10, C#, file-scoped namespaces, 4-space inden
 - **Version:** Default `0.0.0`, CI sets `-p:Version=$buildNum.0.0`. Tags use `vN` format. Auto-updater compares `Version.Major` as integer.
 - **Code signing:** Self-signed cert, auto-generated on first run, stored as `SIGNING_CERTIFICATE`/`SIGNING_CERTIFICATE_PASSWORD` secrets. Requires `GH_PAT` for persistence. 5-year validity, auto-renews at 30 days remaining.
 - **Publishing:** `dotnet publish PaperNexus/PaperNexus.csproj -c Release -r <win-x64|linux-x64> --self-contained true -p:PublishSingleFile=true -p:IncludeNativeLibrariesForSelfExtract=true -p:PublishTrimmed=false`. The Linux output is renamed to `PaperNexus-linux-x64` because the auto-updater looks the asset up by that exact name.
-- **Self-hosted runner:** Both workflows run on `[self-hosted, Linux, X64]`. The runner has no system .NET SDK and its user cannot write `/usr/share/dotnet`, so every job needs `actions/setup-dotnet@v5` with `DOTNET_INSTALL_DIR: ${{ runner.tool_cache }}/dotnet`. Tools that persist between runs (osslsigncode) are reused rather than reinstalled.
+- **Website workflow:** `deploy-website.yml` deploys `website/` to Azure Static Web Apps. It stays on `ubuntu-latest` - `Azure/static-web-apps-deploy` is a Docker container action, which a self-hosted runner cannot run without Docker. Triggered only by changes under `website/`.
+- **Self-hosted runner:** The .NET workflows run on `[self-hosted, Linux, X64]`. The runner has no system .NET SDK and its user cannot write `/usr/share/dotnet`, so every job needs `actions/setup-dotnet@v5` with `DOTNET_INSTALL_DIR: ${{ runner.tool_cache }}/dotnet`. Tools that persist between runs (osslsigncode) are reused rather than reinstalled.
 - **Actions maintenance:** 30-day cycle. Currently `actions/checkout@v6`, `actions/setup-dotnet@v5`. **Next update: August 29, 2026.**
 
 ## Guidelines

--- a/PaperNexus/PaperNexus.csproj
+++ b/PaperNexus/PaperNexus.csproj
@@ -25,7 +25,7 @@
       <IncludeAssets Condition="'$(Configuration)' != 'Debug'">None</IncludeAssets>
       <PrivateAssets Condition="'$(Configuration)' != 'Debug'">All</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="CommunityToolkit.Mvvm" Version="8.4.1" />
+    <PackageReference Include="CommunityToolkit.Mvvm" Version="8.4.2" />
     <PackageReference Include="CronExpressionDescriptor" Version="2.45.0" />
     <PackageReference Include="Cronos" Version="0.11.1" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.5" />


### PR DESCRIPTION
Applies the two live Dependabot proposals - #144 and #138 - against current `main`.

Their own branches were cut before the workflows moved to the self-hosted runner, so merging them directly would have shipped the `checkout` bump without it ever running under the configuration it now has to work with. Rebuilding them here means the checkout bump is exercised by this PR's own `build` job on `paper-nexus-0`.

- `actions/checkout` v6 → v7 across all three workflows. The only behavioural change in v7 blocks checking out fork PRs under `pull_request_target` and `workflow_run`; no workflow here uses either trigger.
- `CommunityToolkit.Mvvm` 8.4.1 → 8.4.2.

Also documents `deploy-website.yml`, which was **missing from `CLAUDE.md`'s repository structure entirely** - I only found it while sweeping for `checkout@v6`. It stays on `ubuntu-latest` deliberately: `Azure/static-web-apps-deploy` is a Docker container action, which a self-hosted runner cannot run without Docker.

Separately closed #140–#143 as superseded - all four bumped Avalonia to 11.3.13, and #146 already took it to 11.3.18.

150/150 tests pass, no vulnerable packages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)