### PR TITLE
chore(deps): bump setup-dotnet, Cronos and CronExpressionDescriptor

### DIFF
--- a/.github/workflows/deploy-wallpaper-service.yml
+++ b/.github/workflows/deploy-wallpaper-service.yml
@@ -23,7 +23,7 @@ jobs:
     # install location. Installing into the runner tool cache is both writable and
     # persistent, so the download happens once and is reused by later runs.
     - name: Set up .NET
-      uses: actions/setup-dotnet@v5
+      uses: actions/setup-dotnet@v6
       with:
         dotnet-version: '10.0.x'
       env:

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -20,7 +20,7 @@ jobs:
     # install location. Installing into the runner tool cache is both writable and
     # persistent, so the download happens once and is reused by later runs.
     - name: Set up .NET
-      uses: actions/setup-dotnet@v5
+      uses: actions/setup-dotnet@v6
       with:
         dotnet-version: '10.0.x'
       env:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -93,7 +93,7 @@ PaperNexus/
 
 ## Dependencies
 
-Avalonia 11.3.12, CommunityToolkit.Mvvm 8.4.0, Cronos 0.11.1, CronExpressionDescriptor 2.45.0, Microsoft.Extensions.Hosting 10.0.3, Newtonsoft.Json 13.0.4, SixLabors.ImageSharp 3.1.12 + Drawing 2.1.7
+Avalonia 11.3.18, CommunityToolkit.Mvvm 8.4.2, Cronos 0.13.0, CronExpressionDescriptor 2.51.0, Microsoft.Extensions.Hosting 10.0.5, Newtonsoft.Json 13.0.4, SixLabors.ImageSharp 3.1.12 + Drawing 2.1.7
 
 ## Settings
 
@@ -129,7 +129,7 @@ Enforced via `.editorconfig`: .NET 10, C#, file-scoped namespaces, 4-space inden
 - **Publishing:** `dotnet publish PaperNexus/PaperNexus.csproj -c Release -r <win-x64|linux-x64> --self-contained true -p:PublishSingleFile=true -p:IncludeNativeLibrariesForSelfExtract=true -p:PublishTrimmed=false`. The Linux output is renamed to `PaperNexus-linux-x64` because the auto-updater looks the asset up by that exact name.
 - **Website workflow:** `deploy-website.yml` deploys `website/` to Azure Static Web Apps. It stays on `ubuntu-latest` - `Azure/static-web-apps-deploy` is a Docker container action, which a self-hosted runner cannot run without Docker. Triggered only by changes under `website/`.
 - **Self-hosted runner:** The .NET workflows run on `[self-hosted, Linux, X64]`. The runner has no system .NET SDK and its user cannot write `/usr/share/dotnet`, so every job needs `actions/setup-dotnet@v5` with `DOTNET_INSTALL_DIR: ${{ runner.tool_cache }}/dotnet`. Tools that persist between runs (osslsigncode) are reused rather than reinstalled.
-- **Actions maintenance:** 30-day cycle. Currently `actions/checkout@v6`, `actions/setup-dotnet@v5`. **Next update: August 29, 2026.**
+- **Actions maintenance:** 30-day cycle. Currently `actions/checkout@v7`, `actions/setup-dotnet@v6`. **Next update: August 29, 2026.**
 
 ## Guidelines
 

--- a/PaperNexus/PaperNexus.csproj
+++ b/PaperNexus/PaperNexus.csproj
@@ -26,8 +26,8 @@
       <PrivateAssets Condition="'$(Configuration)' != 'Debug'">All</PrivateAssets>
     </PackageReference>
     <PackageReference Include="CommunityToolkit.Mvvm" Version="8.4.2" />
-    <PackageReference Include="CronExpressionDescriptor" Version="2.45.0" />
-    <PackageReference Include="Cronos" Version="0.11.1" />
+    <PackageReference Include="CronExpressionDescriptor" Version="2.51.0" />
+    <PackageReference Include="Cronos" Version="0.13.0" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.5" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
     <PackageReference Include="SixLabors.ImageSharp" Version="3.1.12" />


### PR DESCRIPTION
Applies the three **routine** Dependabot proposals (#154, #159, #160) against current `main`, so the workflow bump is exercised by a build on the runner it has to work on - which its own branch predates.

| Package | From | To |
|---|---|---|
| `actions/setup-dotnet` | v5 | v6 |
| `Cronos` | 0.11.1 | 0.13.0 |
| `CronExpressionDescriptor` | 2.45.0 | 2.51.0 |

`setup-dotnet` v6 is an ESM migration with no input changes. **Cronos is pre-1.0**, so a minor bump can change behaviour - the 49 cron tests pass and the running app still computes next-execution times for all three scheduled jobs, which is what would actually break.

## Deliberately excluded
The Avalonia PRs (#156–#158) are **not** included. They move 11.3.18 → **12.1.1**, a major version, and each bumps the core package plus one satellite - merging any single one leaves the packages on mismatched versions. That needs its own pass.

## Also
Resyncs the dependency list in `CLAUDE.md`, which had drifted from the csproj on `CommunityToolkit.Mvvm` (8.4.0 → 8.4.2) and `Microsoft.Extensions.Hosting` (10.0.3 → 10.0.5).

213/213 tests pass, no vulnerable packages, app launches clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)