### PR TITLE
feat(linux): log which wallpaper mechanism was used and why it failed

### DIFF
--- a/PaperNexus/Core/Platform/LinuxWallpaperBackend.cs
+++ b/PaperNexus/Core/Platform/LinuxWallpaperBackend.cs
@@ -9,6 +9,16 @@ namespace PaperNexus.Core.Platform;
 public sealed class LinuxWallpaperBackend : IWallpaperBackend
 {
     private readonly LinuxDesktopEnvironment _desktop = LinuxDesktop.Detect();
+    private readonly ILogger _logger;
+
+    // Logged once rather than on every switch: the detected desktop cannot change while the
+    // app is running, and repeating it would be noise in a rotating log.
+    private bool _loggedDesktop;
+
+    public LinuxWallpaperBackend(ILogger logger)
+    {
+        _logger = logger;
+    }
 
     // The fill style is applied by the same command that sets the image on KDE, so it is
     // cached here and replayed whenever either half changes.
@@ -33,17 +43,33 @@ public sealed class LinuxWallpaperBackend : IWallpaperBackend
             Apply(_currentPath, style);
     }
 
-    private bool Apply(string wallpaperPath, WallpaperFillStyle style) => _desktop switch
+    private bool Apply(string wallpaperPath, WallpaperFillStyle style)
     {
-        LinuxDesktopEnvironment.Kde => ApplyKde(wallpaperPath, style),
-        LinuxDesktopEnvironment.Gnome => ApplyGnome(wallpaperPath, style),
-        _ => ApplyGeneric(wallpaperPath, style),
-    };
+        if (!_loggedDesktop)
+        {
+            _loggedDesktop = true;
+            _logger.LogInformation("Linux desktop detected as {Desktop}; wallpaper will be set via that backend.", _desktop);
+        }
+
+        var applied = _desktop switch
+        {
+            LinuxDesktopEnvironment.Kde => ApplyKde(wallpaperPath, style, _logger),
+            LinuxDesktopEnvironment.Gnome => ApplyGnome(wallpaperPath, style, _logger),
+            _ => ApplyGeneric(wallpaperPath, style),
+        };
+
+        // Warning rather than Debug: a wallpaper that silently fails to change is the whole
+        // failure mode this logging exists to explain.
+        if (!applied)
+            _logger.LogWarning("Could not set the wallpaper on {Desktop}. Tried every mechanism for that desktop; see the attempts above.", _desktop);
+
+        return applied;
+    }
 
     // KDE Plasma stores the wallpaper in each containment's config. Plasma only repaints
     // when the stored value actually changes, and PaperNexus always writes to the same
     // current.png, so the script clears the Image key before writing the real path.
-    private static bool ApplyKde(string wallpaperPath, WallpaperFillStyle style)
+    private static bool ApplyKde(string wallpaperPath, WallpaperFillStyle style, ILogger logger)
     {
         var fillMode = style switch
         {
@@ -70,27 +96,46 @@ public sealed class LinuxWallpaperBackend : IWallpaperBackend
             """;
 
         // The qdbus binary is named differently across Qt versions and distributions.
+        var found = false;
         foreach (var qdbus in new[] { "qdbus6", "qdbus-qt6", "qdbus", "qdbus-qt5" })
         {
             if (!LinuxDesktop.CommandExists(qdbus))
                 continue;
+
+            found = true;
             if (LinuxDesktop.Run(qdbus, "org.kde.plasmashell", "/PlasmaShell", "org.kde.PlasmaShell.evaluateScript", script))
+            {
+                logger.LogDebug("Set wallpaper through {Command} (plasmashell evaluateScript).", qdbus);
                 return true;
+            }
+            logger.LogDebug("{Command} is installed but the plasmashell evaluateScript call failed.", qdbus);
         }
+
+        if (!found)
+            logger.LogDebug("No qdbus binary on PATH (looked for qdbus6, qdbus-qt6, qdbus, qdbus-qt5).");
 
         // Fall back to the shipped CLI tool, which sets the image but not the fill mode.
         if (LinuxDesktop.CommandExists("plasma-apply-wallpaperimage"))
-            return LinuxDesktop.Run("plasma-apply-wallpaperimage", wallpaperPath);
+        {
+            var applied = LinuxDesktop.Run("plasma-apply-wallpaperimage", wallpaperPath);
+            logger.LogDebug("plasma-apply-wallpaperimage {Outcome} (fill mode not applied by this tool).",
+                applied ? "succeeded" : "failed");
+            return applied;
+        }
 
+        logger.LogDebug("plasma-apply-wallpaperimage is not installed either.");
         return false;
     }
 
     // GNOME reads the wallpaper from GSettings. Both the light and dark keys must be set,
     // otherwise the wallpaper appears to not change under the dark colour scheme.
-    private static bool ApplyGnome(string wallpaperPath, WallpaperFillStyle style)
+    private static bool ApplyGnome(string wallpaperPath, WallpaperFillStyle style, ILogger logger)
     {
         if (!LinuxDesktop.CommandExists("gsettings"))
+        {
+            logger.LogDebug("gsettings is not on PATH, so the GNOME backend cannot set the wallpaper.");
             return false;
+        }
 
         var pictureOption = style switch
         {
@@ -115,6 +160,8 @@ public sealed class LinuxWallpaperBackend : IWallpaperBackend
             LinuxDesktop.Run("gsettings", "set", schema, key, "");
             applied |= LinuxDesktop.Run("gsettings", "set", schema, key, imageUri);
         }
+        logger.LogDebug("gsettings picture-uri update {Outcome} (picture-options={Option}).",
+            applied ? "succeeded" : "failed", pictureOption);
         return applied;
     }
 

--- a/PaperNexus/NativeMethods.cs
+++ b/PaperNexus/NativeMethods.cs
@@ -18,14 +18,22 @@ public interface IWallpaperApplier
 // type preserves the IAddSingleton auto-discovery contract in Bootstrapper.
 internal sealed class WallpaperApplier : IWallpaperApplier, IAddSingleton<IWallpaperApplier>
 {
-    private readonly IWallpaperBackend _backend = SelectBackend();
+    private readonly IWallpaperBackend _backend;
 
-    private static IWallpaperBackend SelectBackend()
+    // The logger is passed to the Linux backend so a failed wallpaper switch says which
+    // desktop was detected and which helper commands were tried. Without it the only symptom
+    // is that the wallpaper silently does not change, which is not diagnosable remotely.
+    public WallpaperApplier(ILogger<WallpaperApplier> logger)
+    {
+        _backend = SelectBackend(logger);
+    }
+
+    private static IWallpaperBackend SelectBackend(ILogger logger)
     {
         if (OperatingSystem.IsWindows())
             return new WindowsWallpaperBackend();
         if (OperatingSystem.IsLinux())
-            return new LinuxWallpaperBackend();
+            return new LinuxWallpaperBackend(logger);
         return new NoOpWallpaperBackend();
     }
 

--- a/docs/platform-support.md
+++ b/docs/platform-support.md
@@ -33,6 +33,13 @@ There is no cross-desktop API, so `LinuxWallpaperBackend` dispatches on the dete
   colour scheme.
 - **Anything else** - `feh`, then `xwallpaper`, then `swaybg` if installed.
 
+When a switch fails the backend logs a warning naming the detected desktop, and each
+attempted mechanism logs at debug level (which `--debug` enables) saying whether the helper
+was found and whether it succeeded. That matters because the failure mode is otherwise
+silent: the wallpaper simply does not change. Log growth is bounded regardless - `FileLogger`
+rotates at 5 MB and keeps one previous generation, so the logs directory cannot exceed
+about 10 MB.
+
 Both KDE and GNOME only repaint when the stored value actually changes, and PaperNexus always
 writes the same `current.png`, so each backend clears the key before writing the real path.
 `swaybg` runs for as long as the wallpaper is displayed, so the backend keeps its process and


### PR DESCRIPTION
`LinuxWallpaperBackend` had **no logging at all**. It silently tried `qdbus6` → `qdbus-qt6` → `qdbus` → `qdbus-qt5` → `plasma-apply-wallpaperimage` and returned `false` if every one failed - so the only symptom was that the wallpaper didn't change, with nothing in the log saying which mechanism was attempted or why. That's the hardest thing to diagnose remotely, and SteamOS is exactly where the `qdbus` binary naming is most likely to differ.

## Answering the growth question
Levels are chosen so this costs nothing in normal operation:

| Level | When | In a normal run? |
|---|---|---|
| `Information` | once per session, naming the detected desktop | 1 line |
| `Debug` | per attempt - helper found? succeeded? | **filtered out** unless `--debug` |
| `Warning` | only when every mechanism has failed | only on actual failure |

And it's bounded independently: `FileLogger` rotates at 5 MB keeping one previous generation, so the logs directory can't exceed ~10 MB no matter what. I verified that rotation runs on every write batch rather than trusting the doc comment.

## Verification
Drove the backend directly on both paths.

Success:
```
info: Linux desktop detected as Gnome; wallpaper will be set via that backend.
dbug: gsettings picture-uri update succeeded (picture-options=zoom).
```

Failure (PATH emptied so nothing resolves):
```
dbug: gsettings is not on PATH, so the GNOME backend cannot set the wallpaper.
warn: Could not set the wallpaper on Gnome. Tried every mechanism for that desktop; see the attempts above.
```

⚠️ The KDE-specific debug lines are not exercised here - this machine has no Plasma session. The shared warning summary and the structure are the same, but those particular lines are unrun.

213/213 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)